### PR TITLE
Removes cascadeOnDelete from team_id foreign key

### DIFF
--- a/database/migrations/2020_05_21_100001_create_users_table.php
+++ b/database/migrations/2020_05_21_100001_create_users_table.php
@@ -22,14 +22,14 @@ return new class extends Migration
         if (! Schema::hasTable('users')) {
             Schema::create('users', function (Blueprint $table) {
                 $table->id();
-                $table->foreignId('team_id')->index()->nullable()->constrained()->cascadeOnDelete();
+                $table->foreignId('team_id')->index()->nullable();
                 $table->timestamps();
             });
         }
 
         if (! Schema::hasColumn('users', 'team_id')) {
             Schema::table('users', function (Blueprint $table) {
-                $table->foreignId('team_id')->index()->nullable()->constrained()->cascadeOnDelete();
+                $table->foreignId('team_id')->index()->nullable();
             });
         }
     }


### PR DESCRIPTION
Si on laisse le constrained() et onDeleteCascade() on a cette erreur SQL :

[2025-04-22 11:09:17] testing.ERROR: [SocialController > callback] Error {"exception":"SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`tolery-local-v4-testing`.`users`, CONSTRAINT `users_team_id_foreign` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE) (Connection: mysql, SQL: insert into `users` (`firstname`, `lastname`, `team_id`, `team_role`, `email`, `email_verified_at`, `role`, `updated_at`, `created_at`) values (Mark, Asread, 0, ?, foo@bar.com, 2025-04-22 11:09:17, 2, 2025-04-22 11:09:17, 2025-04-22 11:09:17))"} 
