### PR TITLE
feat: improve admin conversations table

### DIFF
--- a/src/Livewire/Admin/ChatTable.php
+++ b/src/Livewire/Admin/ChatTable.php
@@ -12,7 +12,14 @@ class ChatTable extends FluxDataTable
     {
         return Chat::query()
             ->withCount('messages')
-            ->with(['team', 'user', 'messages' => fn ($q) => $q->whereNotNull('ai_screenshot_path')->latest()->limit(1)])
+            ->with([
+                'team.subscriptions.items',
+                'user',
+                'downloads',
+                'filePurchases',
+                'latestAssistantMessage',
+                'messages' => fn ($q) => $q->whereNotNull('ai_screenshot_path')->latest()->limit(1),
+            ])
             ->withTrashed()
             ->latest();
     }
@@ -25,6 +32,7 @@ class ChatTable extends FluxDataTable
                 'field' => 'name',
                 'searchable' => true,
                 'sortable' => true,
+                'align' => 'left',
                 'render' => fn ($row) => view('ai-cad::livewire.admin.partials.chat-name-cell', ['chat' => $row])->render(),
             ],
             [
@@ -34,12 +42,22 @@ class ChatTable extends FluxDataTable
                 'render' => fn ($row) => '<span class="text-zinc-700 dark:text-zinc-300">'.e($row->team->name ?? '-').'</span>',
             ],
             [
-                'label' => 'Matériau',
-                'field' => 'material_family',
-                'render' => fn ($row) => $row->material_family
-                    ? '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">'
-                        .e($row->material_family->label()).'</span>'
-                    : '<span class="text-zinc-400">-</span>',
+                'label' => 'Abonnement',
+                'field' => 'team_id',
+                'render' => function ($row) {
+                    if (! $row->team) {
+                        return '<span class="text-zinc-400">-</span>';
+                    }
+
+                    $product = $row->team->getSubscriptionProduct();
+
+                    if ($product) {
+                        return '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400">'
+                            .e($product->name).'</span>';
+                    }
+
+                    return '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">Aucun</span>';
+                },
             ],
             [
                 'label' => 'Messages',
@@ -53,13 +71,42 @@ class ChatTable extends FluxDataTable
                 'field' => 'has_generated_piece',
                 'render' => function ($row) {
                     $badges = '';
+
+                    // Générée
                     if ($row->has_generated_piece) {
                         $badges .= '<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400">'
                             .'<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>'
                             .'Générée</span>';
                     }
+
+                    // Téléchargé
+                    if ($row->downloads->isNotEmpty()) {
+                        $badges .= ' <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">'
+                            .'<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>'
+                            .'Téléchargé</span>';
+                    }
+
+                    // Achat sans abonnement (achat CB one-shot)
+                    if ($row->filePurchases->isNotEmpty()) {
+                        $hasSubscription = $row->team?->getSubscriptionProduct() !== null;
+
+                        if (! $hasSubscription) {
+                            $badges .= ' <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">'
+                                .'<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/></svg>'
+                                .'Achat sans abonnement</span>';
+                        }
+                    }
+
+                    // Supprimée
                     if ($row->trashed()) {
                         $badges .= ' <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400">Supprimée</span>';
+                    }
+
+                    // Bug — dernier message assistant = TYPING_INDICATOR (stream jamais terminé)
+                    if ($row->latestAssistantMessage?->message === '[TYPING_INDICATOR]') {
+                        $badges .= ' <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">'
+                            .'<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>'
+                            .'Bug</span>';
                     }
 
                     return $badges ?: '<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">'

--- a/src/Models/Chat.php
+++ b/src/Models/Chat.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Tolery\AiCad\Database\Factories\ChatFactory;
 use Tolery\AiCad\Enum\MaterialFamily;
@@ -75,6 +76,32 @@ class Chat extends Model
     public function getStorageFolder(): string
     {
         return 'ai-chat/'.$this->created_at->format('Y-m').'/chat-'.$this->id;
+    }
+
+    /**
+     * @return HasMany<ChatDownload, $this>
+     */
+    public function downloads(): HasMany
+    {
+        return $this->hasMany(ChatDownload::class);
+    }
+
+    /**
+     * @return HasMany<FilePurchase, $this>
+     */
+    public function filePurchases(): HasMany
+    {
+        return $this->hasMany(FilePurchase::class);
+    }
+
+    /**
+     * @return HasOne<ChatMessage, $this>
+     */
+    public function latestAssistantMessage(): HasOne
+    {
+        return $this->hasOne(ChatMessage::class)
+            ->where('role', ChatMessage::ROLE_ASSISTANT)
+            ->latest();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Suppression de la colonne "Matériau", remplacement par une colonne "Abonnement" affichant le nom du produit d'abonnement de l'équipe ou "Aucun"
- Alignement de la colonne "Conversation" à gauche
- Enrichissement des badges de statut : Téléchargé (bleu), Achat sans abonnement (ambre), Bug (orange — stream jamais terminé)
- Ajout des relations `downloads()`, `filePurchases()`, `latestAssistantMessage()` sur le modèle Chat
- Eager loading des nouvelles relations pour éviter les requêtes N+1

Closes Tolery-Dev/mn-tolery#1969

## Test plan
- [ ] Vérifier que la colonne "Conversation" est alignée à gauche
- [ ] Vérifier que la colonne "Matériau" n'apparaît plus
- [ ] Vérifier que la colonne "Abonnement" affiche le nom du produit ou "Aucun"
- [ ] Vérifier le badge "Téléchargé" sur les conversations avec des downloads
- [ ] Vérifier le badge "Achat sans abonnement" sur les achats CB sans abonnement
- [ ] Vérifier le badge "Bug" sur les conversations avec un stream non terminé

🤖 Generated with [Claude Code](https://claude.com/claude-code)