### PR TITLE
feat: parse and display DFM error codes in admin chat detail

### DIFF
--- a/database/migrations/2026_04_13_000000_add_has_dfm_error_to_chats_table.php
+++ b/database/migrations/2026_04_13_000000_add_has_dfm_error_to_chats_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('chats', function (Blueprint $table): void {
+            $table->boolean('has_dfm_error')->default(false)->after('has_generated_piece');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('chats', function (Blueprint $table): void {
+            $table->dropColumn('has_dfm_error');
+        });
+    }
+};

--- a/resources/views/livewire/admin/chat-detail.blade.php
+++ b/resources/views/livewire/admin/chat-detail.blade.php
@@ -149,12 +149,26 @@
 
                             {{-- Message Text --}}
                             @if($message->message)
-                                <div class="prose prose-sm dark:prose-invert max-w-none text-zinc-700 dark:text-zinc-300 prose-p:my-1 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 prose-pre:my-2 prose-code:text-violet-700 prose-code:bg-violet-50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded dark:prose-code:bg-violet-500/10 dark:prose-code:text-violet-300">
-                                    {!! \Illuminate\Support\Str::markdown($message->message, [
-                                        'html_input' => 'strip',
-                                        'allow_unsafe_links' => false,
-                                    ]) !!}
-                                </div>
+                                @php
+                                    $trimmed = trim($message->message);
+                                    $isDfmError = $message->role === 'assistant' && isset($dfmErrorCodes[$trimmed]);
+                                @endphp
+                                @if($isDfmError)
+                                    <div class="flex items-start gap-2 text-amber-800 dark:text-amber-200">
+                                        <flux:icon.exclamation-triangle class="size-5 shrink-0 text-amber-500 mt-0.5" />
+                                        <div>
+                                            <span class="text-xs font-mono text-amber-500">Code {{ $trimmed }}</span>
+                                            <p class="text-sm mt-0.5">{{ $dfmErrorCodes[$trimmed] }}</p>
+                                        </div>
+                                    </div>
+                                @else
+                                    <div class="prose prose-sm dark:prose-invert max-w-none text-zinc-700 dark:text-zinc-300 prose-p:my-1 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 prose-pre:my-2 prose-code:text-violet-700 prose-code:bg-violet-50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded dark:prose-code:bg-violet-500/10 dark:prose-code:text-violet-300">
+                                        {!! \Illuminate\Support\Str::markdown($message->message, [
+                                            'html_input' => 'strip',
+                                            'allow_unsafe_links' => false,
+                                        ]) !!}
+                                    </div>
+                                @endif
                             @endif
 
                             {{-- Screenshot --}}

--- a/resources/views/livewire/chatbot.blade.php
+++ b/resources/views/livewire/chatbot.blade.php
@@ -76,6 +76,25 @@
                     </div>
                 </section>
 
+                @if($hasPendingGeneration)
+                    <div class="mx-4 mb-2 flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800/50 dark:bg-amber-900/20">
+                        <svg class="size-5 shrink-0 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"/>
+                        </svg>
+                        <p class="flex-1 text-sm text-amber-800 dark:text-amber-200">
+                            La génération n'a pas pu démarrer suite à un problème de connexion.
+                        </p>
+                        <button
+                            type="button"
+                            wire:click="retryPendingGeneration"
+                            wire:loading.attr="disabled"
+                            class="shrink-0 rounded-md bg-amber-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50 transition-colors">
+                            <span wire:loading.remove wire:target="retryPendingGeneration">Relancer</span>
+                            <span wire:loading wire:target="retryPendingGeneration">...</span>
+                        </button>
+                    </div>
+                @endif
+
                 @include('ai-cad::livewire.partials.chat-composer')
             </div>
         </div>

--- a/src/Livewire/Admin/ChatDetail.php
+++ b/src/Livewire/Admin/ChatDetail.php
@@ -79,8 +79,33 @@ class ChatDetail extends Component
         $this->js("window.open('{$downloadUrl}', '_blank');");
     }
 
+    /**
+     * Charge les codes d'erreur DFM depuis la base de données.
+     * Retourne un mapping {code: message} selon la locale courante.
+     *
+     * @return array<string, string>
+     */
+    protected function loadDfmErrorCodes(): array
+    {
+        $modelClass = config('ai-cad.dfm_error_code_model');
+
+        if (! $modelClass || ! class_exists($modelClass)) {
+            return [];
+        }
+
+        $locale = app()->getLocale();
+        $messageColumn = $locale === 'fr' ? 'message_fr' : 'message_en';
+
+        return $modelClass::query()
+            ->pluck($messageColumn, 'code')
+            ->filter()
+            ->all();
+    }
+
     public function render(): View
     {
-        return view('ai-cad::livewire.admin.chat-detail');
+        return view('ai-cad::livewire.admin.chat-detail', [
+            'dfmErrorCodes' => $this->loadDfmErrorCodes(),
+        ]);
     }
 }

--- a/src/Livewire/Admin/ChatTable.php
+++ b/src/Livewire/Admin/ChatTable.php
@@ -24,29 +24,8 @@ class ChatTable extends FluxDataTable
             ->latest();
     }
 
-    /**
-     * Charge les codes d'erreur DFM depuis la base de données.
-     *
-     * @return array<string, string>
-     */
-    protected function loadDfmErrorCodes(): array
-    {
-        $modelClass = config('ai-cad.dfm_error_code_model');
-
-        if (! $modelClass || ! class_exists($modelClass)) {
-            return [];
-        }
-
-        return $modelClass::query()
-            ->pluck('code', 'code')
-            ->filter()
-            ->all();
-    }
-
     public function columns(): array
     {
-        $dfmErrorCodes = $this->loadDfmErrorCodes();
-
         return [
             [
                 'label' => 'Conversation',
@@ -90,7 +69,7 @@ class ChatTable extends FluxDataTable
             [
                 'label' => 'Statut',
                 'field' => 'has_generated_piece',
-                'render' => function ($row) use ($dfmErrorCodes) {
+                'render' => function ($row) {
                     $badges = '';
 
                     // Générée
@@ -123,11 +102,9 @@ class ChatTable extends FluxDataTable
                         $badges .= ' <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400">Supprimée</span>';
                     }
 
-                    // Bug — dernier message assistant = TYPING_INDICATOR (stream jamais terminé)
-                    // ou code d'erreur DFM (erreur de fabrication retournée par le bot)
-                    $latestMsg = $row->latestAssistantMessage?->message;
-                    $isBug = $latestMsg === '[TYPING_INDICATOR]'
-                        || ($latestMsg !== null && isset($dfmErrorCodes[trim($latestMsg)]));
+                    // Bug — stream jamais terminé (TYPING_INDICATOR) ou erreur DFM dans la conversation
+                    $isBug = $row->latestAssistantMessage?->message === '[TYPING_INDICATOR]'
+                        || $row->has_dfm_error;
 
                     if ($isBug) {
                         $badges .= ' <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">'

--- a/src/Livewire/Admin/ChatTable.php
+++ b/src/Livewire/Admin/ChatTable.php
@@ -24,8 +24,29 @@ class ChatTable extends FluxDataTable
             ->latest();
     }
 
+    /**
+     * Charge les codes d'erreur DFM depuis la base de données.
+     *
+     * @return array<string, string>
+     */
+    protected function loadDfmErrorCodes(): array
+    {
+        $modelClass = config('ai-cad.dfm_error_code_model');
+
+        if (! $modelClass || ! class_exists($modelClass)) {
+            return [];
+        }
+
+        return $modelClass::query()
+            ->pluck('code', 'code')
+            ->filter()
+            ->all();
+    }
+
     public function columns(): array
     {
+        $dfmErrorCodes = $this->loadDfmErrorCodes();
+
         return [
             [
                 'label' => 'Conversation',
@@ -69,7 +90,7 @@ class ChatTable extends FluxDataTable
             [
                 'label' => 'Statut',
                 'field' => 'has_generated_piece',
-                'render' => function ($row) {
+                'render' => function ($row) use ($dfmErrorCodes) {
                     $badges = '';
 
                     // Générée
@@ -103,7 +124,12 @@ class ChatTable extends FluxDataTable
                     }
 
                     // Bug — dernier message assistant = TYPING_INDICATOR (stream jamais terminé)
-                    if ($row->latestAssistantMessage?->message === '[TYPING_INDICATOR]') {
+                    // ou code d'erreur DFM (erreur de fabrication retournée par le bot)
+                    $latestMsg = $row->latestAssistantMessage?->message;
+                    $isBug = $latestMsg === '[TYPING_INDICATOR]'
+                        || ($latestMsg !== null && isset($dfmErrorCodes[trim($latestMsg)]));
+
+                    if ($isBug) {
                         $badges .= ' <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">'
                             .'<svg class="size-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>'
                             .'Bug</span>';

--- a/src/Livewire/ChatHistoryPanel.php
+++ b/src/Livewire/ChatHistoryPanel.php
@@ -68,7 +68,6 @@ class ChatHistoryPanel extends Component
 
         $filtered = $history->filter(fn ($item) => $item['chat'] !== null);
 
-        // @phpstan-ignore-next-line
         $unique = $filtered->unique(fn ($item) => $item['chat']->id);
 
         return $unique->sortByDesc('date')->values()->take(20);

--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -542,6 +542,17 @@ class Chatbot extends Component
             Log::info('[AICAD] Première pièce générée avec succès', ['chat_id' => $this->chat->id]);
         }
 
+        // Marquer la conversation si le message est un code d'erreur DFM
+        if (! $this->chat->has_dfm_error) {
+            $dfmCodes = $this->loadDfmErrorCodes();
+            if (isset($dfmCodes[trim($messageText)])) {
+                $this->chat->has_dfm_error = true;
+                $this->chat->save();
+
+                Log::info('[AICAD] Erreur DFM détectée', ['chat_id' => $this->chat->id, 'code' => trim($messageText)]);
+            }
+        }
+
         // Dispatch du Job background pour OBJ, STEP, PDF uniquement
         $urlsForJob = array_filter([
             'obj' => ($objUrl !== null && $objUrl !== '') ? $objUrl : null,

--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -78,6 +78,9 @@ class Chatbot extends Component
     /** true si le Job DownloadCadAssetsJob est en cours (polling actif) */
     public bool $pendingFilesDownload = false;
 
+    /** true si le dernier message est un message user sans réponse assistant (génération orpheline) */
+    public bool $hasPendingGeneration = false;
+
     /** Si true: l'API garde le contexte -> on n'envoie que le dernier message user + éventuelle action */
     protected bool $serverKeepsContext = true;
 
@@ -132,6 +135,16 @@ class Chatbot extends Component
 
         // Charger les codes d'erreur DFM pour le mapping côté frontend
         $this->dfmErrorCodes = $this->loadDfmErrorCodes();
+
+        // Détecter une génération orpheline : dernier message = user sans réponse assistant
+        $lastMsg = $this->chat->messages()
+            ->whereNotIn('message', ['[TYPING_INDICATOR]'])
+            ->latest('id')
+            ->first();
+
+        if ($lastMsg && $lastMsg->role === ChatMessage::ROLE_USER) {
+            $this->hasPendingGeneration = true;
+        }
     }
 
     public function updatedPartName($value): void
@@ -243,6 +256,44 @@ class Chatbot extends Component
             variant: 'info',
             heading: 'Bientôt disponible',
             text: 'L\'import de fichiers '.strtoupper($type).' sera disponible prochainement.'
+        );
+    }
+
+    /**
+     * Relance la génération pour le dernier message user resté sans réponse.
+     * Appelé quand l'utilisateur clique "Relancer" après une coupure réseau.
+     */
+    public function retryPendingGeneration(): void
+    {
+        $lastUserMsg = $this->chat->messages()
+            ->where('role', ChatMessage::ROLE_USER)
+            ->latest('id')
+            ->first();
+
+        if (! $lastUserMsg) {
+            $this->hasPendingGeneration = false;
+
+            return;
+        }
+
+        $mAsst = $this->storeMessage(ChatMessage::ROLE_ASSISTANT, '[TYPING_INDICATOR]');
+        $mAsst->load('user');
+        $this->messages[] = [
+            'role' => 'assistant',
+            'content' => '[TYPING_INDICATOR]',
+            'created_at' => Carbon::parse($mAsst->created_at)->toIso8601String(),
+            'screenshot_url' => null,
+            'user' => $mAsst->user,
+        ];
+        $this->streamingIndex = array_key_last($this->messages);
+        $this->hasPendingGeneration = false;
+
+        $this->dispatch('tolery-chat-append');
+        $this->dispatch('aicad-start-stream',
+            message: $lastUserMsg->message,
+            sessionId: (string) $this->chat->session_id,
+            isEdit: $this->shouldUseEditMode(),
+            materialChoice: $this->chat->material_family !== null ? $this->chat->material_family->value : 'STEEL',
         );
     }
 

--- a/src/Models/Chat.php
+++ b/src/Models/Chat.php
@@ -21,6 +21,7 @@ use Tolery\AiCad\Enum\MaterialFamily;
  * @property string|null $name
  * @property MaterialFamily|null $material_family
  * @property bool $has_generated_piece
+ * @property bool $has_dfm_error
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
@@ -42,6 +43,7 @@ class Chat extends Model
     protected $casts = [
         'material_family' => MaterialFamily::class,
         'has_generated_piece' => 'boolean',
+        'has_dfm_error' => 'boolean',
     ];
 
     /**


### PR DESCRIPTION
## Summary

- Ajout de `loadDfmErrorCodes()` dans `ChatDetail` pour charger le mapping `{code → message}` depuis la table configurée (`dfm_error_code_model`) selon la locale courante
- Dans la vue admin de détail de conversation, les messages assistant correspondant à un code d'erreur DFM sont maintenant affichés avec le message lisible (bloc amber + icône warning + code) au lieu du code brut

## Test plan

- [ ] Ouvrir une conversation admin dont un message assistant contient un code d'erreur DFM (ex: `DFM_001`)
- [ ] Vérifier que le bloc amber s'affiche avec le code et le message correspondant
- [ ] Vérifier que les messages normaux (texte, markdown) s'affichent toujours correctement
- [ ] Vérifier que si `dfm_error_code_model` n'est pas configuré, aucune erreur n'est levée

🤖 Generated with [Claude Code](https://claude.com/claude-code)