### PR TITLE
fix: corriger mauvais label de version dans le panel historique chatbot

### DIFF
--- a/resources/views/livewire/chat-history-panel.blade.php
+++ b/resources/views/livewire/chat-history-panel.blade.php
@@ -22,10 +22,7 @@
                 @forelse ($this->history as $item)
                     @php
                         $chat = $item['chat'];
-                        $latestMessage = $chat->messages()
-                            ->whereNotNull('ai_cad_path')
-                            ->orderByDesc('created_at')
-                            ->first();
+                        $latestMessage = $chat->messages->first();
                         $screenshotUrl = $latestMessage?->getScreenshotUrl();
                         $versionLabel = $latestMessage?->getVersionLabel();
                     @endphp


### PR DESCRIPTION
## Problème

Dans le panel "historique" du chatbot, le label de version affiché (ex: v2) ne correspondait pas à la version réellement téléchargée (ex: v1).

## Cause

La vue `chat-history-panel.blade.php` recalculait `$latestMessage` avec `->whereNotNull('ai_cad_path')`, alors que `ZipGeneratorService` utilise `->whereNotNull('ai_step_path')` pour générer le ZIP. Ces deux filtres pouvaient retourner des messages différents.

## Correction

Utilisation de la relation Eloquent déjà eager-loadée par le composant Livewire (filtrée sur `ai_step_path`) au lieu de refaire une requête SQL avec un filtre différent.

**Bénéfices :**
- Label affiché = fichier réellement téléchargé ✅
- Élimination des requêtes N+1 en réutilisant les données préchargées ✅

## Références

Fixes Tolery-Dev/mn-tolery#1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)