### PR TITLE
feat: afficher détail HT / TVA 20% / TTC dans la modal one-shot (#1874)

### DIFF
--- a/resources/views/livewire/partials/purchase-modal.blade.php
+++ b/resources/views/livewire/partials/purchase-modal.blade.php
@@ -67,9 +67,24 @@
                                 Paiement unique pour ce fichier uniquement
                             </flux:subheading>
                             @if(isset($downloadStatus['options']['purchase_price']))
-                                <div class="text-3xl font-bold text-zinc-900 mb-2">
-                                    {{ number_format($downloadStatus['options']['purchase_price'] / 100, 2) }}€
-                                    <span class="text-base font-normal text-zinc-600">HT</span>
+                                @php
+                                    $ht = $downloadStatus['options']['purchase_price'];
+                                    $tva = round($ht * 0.20);
+                                    $ttc = $ht + $tva;
+                                @endphp
+                                <div class="mb-4 space-y-1">
+                                    <div class="flex justify-between text-sm text-zinc-700">
+                                        <span>Montant fichier CAO</span>
+                                        <span>{{ number_format($ht / 100, 2, ',', ' ') }} € HT</span>
+                                    </div>
+                                    <div class="flex justify-between text-sm text-zinc-500">
+                                        <span>TVA 20%</span>
+                                        <span>{{ number_format($tva / 100, 2, ',', ' ') }} €</span>
+                                    </div>
+                                    <div class="flex justify-between text-base font-bold text-violettes pt-1 border-t border-zinc-200">
+                                        <span>Total TTC</span>
+                                        <span>{{ number_format($ttc / 100, 2, ',', ' ') }} €</span>
+                                    </div>
                                 </div>
                             @endif
                             <ul class="space-y-2 text-sm text-zinc-600">


### PR DESCRIPTION
## Problème

La modal de paiement one-shot n'affichait que le prix HT, sans détail de la TVA ni du total TTC.

## Solution

Ajout du détail complet dans la modal :
- **Montant HT** — prix unitaire
- **TVA 20%** — calculée automatiquement (×0.20)
- **Total TTC** — en violet gras (`text-violettes`), mise en évidence visuelle

## Rendu

```
Montant fichier CAO     49,00 € HT
TVA 20%                  9,80 €
────────────────────────────────
Total TTC               58,80 €   ← violet, gras
```

## Références

Closes Tolery-Dev/mn-tolery#1874

🤖 Generated with [Claude Code](https://claude.com/claude-code)