### PR TITLE
fix: statut Téléchargé dans la datatable admin des chats (#1928)

### DIFF
--- a/tests/Feature/ChatTableStatusTest.php
+++ b/tests/Feature/ChatTableStatusTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Tolery\AiCad\Models\Chat;
+use Tolery\AiCad\Models\ChatDownload;
+use Tolery\AiCad\Models\ChatTeam;
+
+beforeEach(function () {
+    config(['ai-cad.chat_team_model' => ChatTeam::class]);
+});
+
+describe('ChatTable - statut Téléchargé', function () {
+    it('indique qu\'un chat sans téléchargement n\'a pas le statut Téléchargé', function () {
+        $team = ChatTeam::factory()->create();
+        $chat = Chat::factory()->create(['team_id' => $team->id]);
+
+        $chat->load('downloads');
+
+        expect($chat->downloads->isNotEmpty())->toBeFalse();
+    });
+
+    it('indique qu\'un chat avec un téléchargement a le statut Téléchargé', function () {
+        $team = ChatTeam::factory()->create();
+        $chat = Chat::factory()->create(['team_id' => $team->id]);
+
+        ChatDownload::create([
+            'team_id' => $team->id,
+            'chat_id' => $chat->id,
+            'message_id' => null,
+            'downloaded_at' => now(),
+        ]);
+
+        $chat->load('downloads');
+
+        expect($chat->downloads->isNotEmpty())->toBeTrue();
+    });
+
+    it('indique qu\'un chat avec plusieurs téléchargements a le statut Téléchargé', function () {
+        $team = ChatTeam::factory()->create();
+        $chat = Chat::factory()->create(['team_id' => $team->id]);
+
+        ChatDownload::create([
+            'team_id' => $team->id,
+            'chat_id' => $chat->id,
+            'message_id' => null,
+            'downloaded_at' => now()->subDay(),
+        ]);
+
+        ChatDownload::create([
+            'team_id' => $team->id,
+            'chat_id' => $chat->id,
+            'message_id' => null,
+            'downloaded_at' => now(),
+        ]);
+
+        $chat->load('downloads');
+
+        expect($chat->downloads->isNotEmpty())->toBeTrue()
+            ->and($chat->downloads->count())->toBe(2);
+    });
+
+    it('ne confond pas les téléchargements d\'un autre chat', function () {
+        $team = ChatTeam::factory()->create();
+        $chat1 = Chat::factory()->create(['team_id' => $team->id]);
+        $chat2 = Chat::factory()->create(['team_id' => $team->id]);
+
+        ChatDownload::create([
+            'team_id' => $team->id,
+            'chat_id' => $chat2->id,
+            'message_id' => null,
+            'downloaded_at' => now(),
+        ]);
+
+        $chat1->load('downloads');
+
+        expect($chat1->downloads->isNotEmpty())->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Contexte

Le ticket #1928 demande d'afficher un statut **Téléchargé** dans la datatable admin `/admin/tolerycad/chats` quand un utilisateur a déjà téléchargé son fichier CAO depuis la conversation.

La fonctionnalité était déjà implémentée dans `src/Livewire/Admin/ChatTable.php` (badge bleu "Téléchargé" via `$row->downloads->isNotEmpty()`), mais aucun test ne couvrait ce comportement.

## Changements

- Ajout de `tests/Feature/ChatTableStatusTest.php` avec 4 cas :
  - Chat sans téléchargement → statut non affiché
  - Chat avec un téléchargement → statut affiché
  - Chat avec plusieurs téléchargements → statut affiché (count = 2)
  - Téléchargements d'un autre chat non confondus

## Test plan

- [ ] `./vendor/bin/pest tests/Feature/ChatTableStatusTest.php` → 4 tests passent, 5 assertions
- [ ] `./vendor/bin/pint --dirty` → aucune correction nécessaire

🤖 Generated with [Claude Code](https://claude.com/claude-code)