### PR TITLE
fix: cohérence d'affichage entre lecture et édition dans le panel CAD config

### DIFF
--- a/resources/views/partials/cad-config-panel.blade.php
+++ b/resources/views/partials/cad-config-panel.blade.php
@@ -273,7 +273,7 @@
                                 </div>
                                 <div class="flex justify-between items-center">
                                     <span class="text-gray-500">Ø perçage</span>
-                                    <span class="font-medium text-gray-600" x-text="fmtDiameter(getDiameterFromThread(selection.metrics.thread || getThreadFromDiameter(selection.metrics.diameter)) || selection.metrics.diameter)"></span>
+                                    <span class="font-medium text-gray-600" x-text="fmt(getDiameterFromThread(selection.metrics.thread || getThreadFromDiameter(selection.metrics.diameter)) || selection.metrics.diameter)"></span>
                                 </div>
                                 <div class="flex justify-between items-center">
                                     <span class="text-gray-500">Profondeur</span>
@@ -833,13 +833,12 @@
                     this.x = Math.min(Math.max(this.x, 12), Math.max(maxX, 12))
                     this.y = Math.min(Math.max(this.y, 12), Math.max(maxY, 12))
                 },
-                // Helpers d'affichage
+                // Helpers d'affichage. Précision adaptative : entier si entier
+                // (ex. 100 → "100 mm"), sinon 1 décimale (ex. 2.5 → "2.5 mm").
+                // Garantit la cohérence entre lecture et édition (les inputs
+                // x-model.number affichent les valeurs brutes sans arrondi).
                 fmt(v) {
-                    return (v == null) ? '—' : `${(+v).toFixed(0)} mm`
-                },
-                fmtDiameter(v) {
                     if (v == null) return '—';
-                    // Afficher 1 décimale si nécessaire (2.5 mm), sinon entier (3 mm)
                     const num = +v;
                     return num % 1 === 0 ? `${num.toFixed(0)} mm` : `${num.toFixed(1)} mm`;
                 },


### PR DESCRIPTION
## Contexte

Bug remonté pendant les tests : sur les congés (fillet), le panel affiche **« Rayon : 3 mm »** en lecture mais quand on clique « Modifier », l'input affiche **« 2.5 »**. Pareil potentiellement sur d'autres métriques sub-millimétriques.

## Cause

Le helper `fmt(v)` utilisait `(+v).toFixed(0)` (arrondi entier) tandis que les inputs `x-model.number` affichent les valeurs brutes sans arrondi. Le badge « Congé R2.5 » et l'input à 2.5 confirment que la valeur réelle est 2.5 — c'est l'affichage en lecture qui ment.

## Changement

`fmt()` adopte la même précision adaptative que `fmtDiameter` : entier si entier (`100` → `"100 mm"`), sinon 1 décimale (`2.5` → `"2.5 mm"`). `fmtDiameter` devenait redondant — supprimé, son seul appel remplacé par `fmt`.

Couvre tous les usages de `fmt` dans le panel (Longueur, Largeur, Profondeur, Rayon, Diamètre, Épaisseur, dimensions globales du bloc Détails).

## Test plan

- [ ] Cliquer un congé : le rayon affiché en lecture doit matcher la valeur du badge (ex: « R2.5 » ↔ « 2.5 mm »)
- [ ] Passer en mode édition : l'input doit afficher la même valeur (2.5)
- [ ] Vérifier que les valeurs entières sont toujours affichées sans décimale (ex: 100 mm pas 100.0 mm)
- [ ] Vérifier les autres métriques (perçage, taraudage, longueurs/largeurs) — pas de régression

🤖 Generated with [Claude Code](https://claude.com/claude-code)