### PR TITLE
fix: détection des codes d'erreur DFM noyés dans un texte (#2065)

### DIFF
--- a/resources/views/livewire/partials/chat-messages.blade.php
+++ b/resources/views/livewire/partials/chat-messages.blade.php
@@ -53,7 +53,7 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
                     </svg>
                     <div>
-                        <span class="text-xs font-mono text-amber-500" x-text="'Code ' + content.trim()"></span>
+                        <span class="text-xs font-mono text-amber-500" x-text="'Code ' + (matchedErrorCode || content.trim())"></span>
                         <p class="text-sm mt-0.5" x-text="errorMessage"></p>
                     </div>
                 </div>
@@ -80,15 +80,31 @@
         isTyping: false,
         isErrorCode: false,
         errorMessage: '',
+        matchedErrorCode: '',
         displayedContent: '',
 
         checkDfmErrorCode(text) {
             if (this.role !== 'assistant' || !text) return false;
             var trimmed = text.trim();
+            // Cas 1 : le bot renvoie uniquement le code (ex: "104.1")
             if (this.dfmErrorCodes[trimmed]) {
                 this.isErrorCode = true;
                 this.errorMessage = this.dfmErrorCodes[trimmed];
+                this.matchedErrorCode = trimmed;
                 return true;
+            }
+            // Cas 2 : le code est noyé dans un texte (ex: "Erreur lors de la
+            // génération : 104.1 — veuillez réessayer"). On parcourt les codes
+            // connus et on cherche le premier qui apparaît dans le message.
+            for (var code in this.dfmErrorCodes) {
+                if (!Object.prototype.hasOwnProperty.call(this.dfmErrorCodes, code)) continue;
+                var pattern = new RegExp('(^|[^\\d.])' + code.replace(/\./g, '\\.') + '($|[^\\d.])');
+                if (pattern.test(text)) {
+                    this.isErrorCode = true;
+                    this.errorMessage = this.dfmErrorCodes[code];
+                    this.matchedErrorCode = code;
+                    return true;
+                }
             }
             return false;
         },


### PR DESCRIPTION
## Contexte

Ticket [Tolery-Dev/mn-tolery#2065](https://github.com/Tolery-Dev/mn-tolery/issues/2065) — feedback Romain : le bot répond parfois un message qui contient un code d'erreur DFM (ex: \`104.1\`) mais sans le texte explicatif associé, alors que la table \`dfm_error_codes\` contient bien ce code et son message FR.

## Cause

`checkDfmErrorCode()` (`chat-messages.blade.php`) ne matchait que les contenus dont le `trim()` était **exactement** un code de la map. Si le bot renvoyait le code noyé dans un texte plus long (ex: « Erreur lors de la génération : 104.1 — veuillez réessayer »), le match échouait et l'utilisateur voyait juste le message brut, sans le panneau jaune avec l'explication FR.

## Changement

On garde le match exact comme cas rapide, et on ajoute un cas 2 : on parcourt la map `dfmErrorCodes` et on cherche chaque code dans le content via une regex `(^|[^\\d.])<code>($|[^\\d.])` (garde-fou pour éviter qu'un sous-pattern type \`104.1\` ne matche dans \`1104.10\`). Le label du panneau jaune affiche désormais `matchedErrorCode` (le code réellement reconnu) au lieu du content brut.

## Test plan

- [ ] Bot renvoie exactement \`"104.1"\` → panneau jaune « Code 104.1 » + message FR (pas de régression)
- [ ] Bot renvoie un texte type \`"Erreur 104.1 lors de l'exécution"\` → même panneau jaune avec « Code 104.1 »
- [ ] Bot renvoie un texte sans code DFM → rendu markdown normal, pas de panneau jaune

🤖 Generated with [Claude Code](https://claude.com/claude-code)