### PR TITLE
fix: éviter frequency NULL sur produits synchronisés et durcir LimitRenew

### DIFF
--- a/src/Jobs/LimitRenew.php
+++ b/src/Jobs/LimitRenew.php
@@ -4,6 +4,7 @@ namespace Tolery\AiCad\Jobs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 use Tolery\AiCad\Models\Limit;
 
 class LimitRenew implements ShouldQueue
@@ -14,17 +15,28 @@ class LimitRenew implements ShouldQueue
 
     public function handle(): void
     {
-
-        // On vérifie que l'abonnement est encore valable
         $team = $this->limit->team;
 
-        if ($team->subscribed()) {
-            // créer une nouvelle limite à partir de l'ancienne
-            $newLimit = $this->limit->replicate();
-
-            $newLimit->start_date = now();
-            $newLimit->end_date = $this->limit->product->frequency->addTime(now());
-            $newLimit->save();
+        if (! $team->subscribed()) {
+            return;
         }
+
+        $product = $this->limit->product;
+        $frequency = $product?->frequency;
+
+        if ($frequency === null) {
+            Log::warning('[LimitRenew] Skipping renewal: product or frequency is null', [
+                'limit_id' => $this->limit->id,
+                'team_id' => $this->limit->team_id,
+                'product_id' => $product?->id,
+            ]);
+
+            return;
+        }
+
+        $newLimit = $this->limit->replicate();
+        $newLimit->start_date = now();
+        $newLimit->end_date = $frequency->addTime(now());
+        $newLimit->save();
     }
 }

--- a/src/Services/StripeSyncService.php
+++ b/src/Services/StripeSyncService.php
@@ -6,6 +6,7 @@ use Stripe\Exception\ApiErrorException;
 use Stripe\Price;
 use Stripe\Product;
 use Stripe\StripeClient;
+use Tolery\AiCad\Enum\ResetFrequency;
 use Tolery\AiCad\Models\SubscriptionPrice;
 use Tolery\AiCad\Models\SubscriptionProduct;
 
@@ -76,15 +77,26 @@ class StripeSyncService
     {
         $filesAllowed = $stripeProduct->metadata->files_allowed ?? null;
 
-        return SubscriptionProduct::updateOrCreate(
-            ['stripe_id' => $stripeProduct->id],
-            [
-                'name' => $stripeProduct->name,
-                'description' => $stripeProduct->description ?? '',
-                'active' => $stripeProduct->active,
-                'files_allowed' => $filesAllowed ? (int) $filesAllowed : null,
-            ]
-        );
+        $product = SubscriptionProduct::firstOrNew(['stripe_id' => $stripeProduct->id]);
+
+        $product->name = $stripeProduct->name;
+        $product->description = $stripeProduct->description ?? '';
+        $product->active = $stripeProduct->active;
+        $product->files_allowed = $filesAllowed ? (int) $filesAllowed : null;
+
+        // Frequency drives the quota reset cadence used by LimitRenew.
+        // Stripe products do not carry this notion, so we default to MONTHLY
+        // on create and self-heal any pre-existing NULL row from earlier syncs.
+        // Stripe metadata `frequency=monthly|yearly` overrides the default.
+        if (! $product->exists || $product->frequency === null) {
+            $metadataFrequency = $stripeProduct->metadata->frequency ?? null;
+            $product->frequency = ResetFrequency::tryFrom((string) $metadataFrequency)
+                ?? ResetFrequency::MONTHLY;
+        }
+
+        $product->save();
+
+        return $product;
     }
 
     protected function syncPrice(Price $stripePrice, string $stripeProductId): ?SubscriptionPrice

--- a/tests/Feature/Job/LimitRenewTest.php
+++ b/tests/Feature/Job/LimitRenewTest.php
@@ -4,6 +4,7 @@ use Laravel\Cashier\Subscription;
 use Tolery\AiCad\Jobs\LimitRenew;
 use Tolery\AiCad\Models\ChatTeam;
 use Tolery\AiCad\Models\Limit;
+use Tolery\AiCad\Models\SubscriptionProduct;
 
 use function Pest\Laravel\assertDatabaseCount;
 
@@ -48,5 +49,26 @@ test('dont renew limit for unsubscribe team', function () {
 
     $limitRenewJob->handle();
 
+    assertDatabaseCount('subscription_has_limits', 1);
+});
+
+test('skip renewal without crashing when product frequency is null', function () {
+
+    $product = SubscriptionProduct::factory()->create(['frequency' => null]);
+
+    $limit = Limit::factory()
+        ->for($product, 'product')
+        ->past()
+        ->create();
+
+    $team = Mockery::mock(ChatTeam::class);
+    $team->shouldReceive('subscribed')->andReturn(true);
+    $limit->setRelation('team', $team);
+
+    $limitRenewJob = new LimitRenew($limit);
+
+    $limitRenewJob->handle();
+
+    // No new limit created — the job should log and return, not throw.
     assertDatabaseCount('subscription_has_limits', 1);
 });

--- a/tests/Feature/StripeSyncServiceTest.php
+++ b/tests/Feature/StripeSyncServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Stripe\Product;
+use Stripe\StripeClient;
 use Tolery\AiCad\Enum\ResetFrequency;
 use Tolery\AiCad\Models\SubscriptionProduct;
 use Tolery\AiCad\Services\AiCadStripe;
@@ -30,7 +31,7 @@ function makeStripeProduct(array $overrides = []): Product
 }
 
 beforeEach(function () {
-    $this->stripeMock = Mockery::mock(\Stripe\StripeClient::class);
+    $this->stripeMock = Mockery::mock(StripeClient::class);
     $this->aiCadStripe = Mockery::mock(AiCadStripe::class);
     $this->aiCadStripe->shouldReceive('client')->andReturn($this->stripeMock);
 });

--- a/tests/Feature/StripeSyncServiceTest.php
+++ b/tests/Feature/StripeSyncServiceTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Stripe\Product;
+use Tolery\AiCad\Enum\ResetFrequency;
+use Tolery\AiCad\Models\SubscriptionProduct;
+use Tolery\AiCad\Services\AiCadStripe;
+use Tolery\AiCad\Services\StripeSyncService;
+
+/**
+ * Helper to invoke the protected syncProduct method via reflection.
+ */
+function invokeSyncProduct(StripeSyncService $service, Product $stripeProduct): SubscriptionProduct
+{
+    $reflection = new ReflectionMethod($service, 'syncProduct');
+    $reflection->setAccessible(true);
+
+    return $reflection->invoke($service, $stripeProduct);
+}
+
+function makeStripeProduct(array $overrides = []): Product
+{
+    return Product::constructFrom(array_merge([
+        'id' => 'prod_test_'.bin2hex(random_bytes(4)),
+        'object' => 'product',
+        'name' => 'Pro',
+        'description' => 'Plan Pro',
+        'active' => true,
+        'metadata' => ['files_allowed' => '100'],
+    ], $overrides));
+}
+
+beforeEach(function () {
+    $this->stripeMock = Mockery::mock(\Stripe\StripeClient::class);
+    $this->aiCadStripe = Mockery::mock(AiCadStripe::class);
+    $this->aiCadStripe->shouldReceive('client')->andReturn($this->stripeMock);
+});
+
+it('sets frequency to MONTHLY by default when creating a new product', function () {
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct();
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->frequency)->toBe(ResetFrequency::MONTHLY);
+});
+
+it('uses Stripe metadata frequency when provided', function () {
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct([
+        'metadata' => ['files_allowed' => '100', 'frequency' => 'yearly'],
+    ]);
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->frequency)->toBe(ResetFrequency::YEARLY);
+});
+
+it('preserves an existing non-null frequency on update', function () {
+    $existing = SubscriptionProduct::factory()->create([
+        'stripe_id' => 'prod_existing_yearly',
+        'frequency' => ResetFrequency::YEARLY,
+    ]);
+
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct(['id' => 'prod_existing_yearly']);
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->id)->toBe($existing->id)
+        ->and($product->frequency)->toBe(ResetFrequency::YEARLY);
+});
+
+it('heals an existing product whose frequency is NULL', function () {
+    $existing = SubscriptionProduct::factory()->create([
+        'stripe_id' => 'prod_existing_null',
+        'frequency' => null,
+    ]);
+
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct(['id' => 'prod_existing_null']);
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->id)->toBe($existing->id)
+        ->and($product->frequency)->toBe(ResetFrequency::MONTHLY);
+});
+
+it('updates basic attributes from Stripe payload', function () {
+    SubscriptionProduct::factory()->create([
+        'stripe_id' => 'prod_update_attrs',
+        'name' => 'Old Name',
+        'frequency' => ResetFrequency::MONTHLY,
+    ]);
+
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct([
+        'id' => 'prod_update_attrs',
+        'name' => 'New Name',
+        'description' => 'Updated description',
+        'active' => false,
+        'metadata' => ['files_allowed' => '50'],
+    ]);
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->name)->toBe('New Name')
+        ->and($product->description)->toBe('Updated description')
+        ->and($product->active)->toBeFalse()
+        ->and($product->files_allowed)->toBe(50)
+        ->and($product->frequency)->toBe(ResetFrequency::MONTHLY);
+});


### PR DESCRIPTION
## Contexte

La commande `ai-cad:sync-stripe` recrée les `SubscriptionProduct` sans renseigner la colonne `frequency`. Cela entraîne le crash quotidien du job `LimitRenew` (cron 1h00 via `ai-cad:auto-renewal`) :

```
Call to a member function addTime() on null
src/Jobs/LimitRenew.php:26
```

`product->frequency` est `null` → on appelle `->addTime()` sur null. Bug observé en preprod après un sync, mais valable pour tout produit dont la frequency a été perdue.

## Changements

### `StripeSyncService::syncProduct`
- Refactor `updateOrCreate` → `firstOrNew` + assignations explicites pour pouvoir distinguer create vs update
- **Création** : `frequency` par défaut à `ResetFrequency::MONTHLY` (cohérent avec l'UI ToleryCAD qui affiche « X fichiers / mois » même sur les abos annuels)
- **Update** : préserve la `frequency` existante non-null, mais soigne (heal) les lignes où elle est NULL
- Métadonnée Stripe `frequency=monthly|yearly` accepted comme override

### `LimitRenew::handle`
- Defensive : si `product` ou `frequency` est null, log un warning et `return` au lieu de throw
- Garde le queue worker sain tout en surfacing l'inconsistance des données

## Tests

- `tests/Feature/StripeSyncServiceTest.php` (nouveau, 5 cas) : default MONTHLY, override metadata, préservation, healing NULL, mise à jour des autres attributs
- `tests/Feature/Job/LimitRenewTest.php` : ajout du cas defensive null frequency
- 13 tests Limit/Sync/Product/AutoRenewal : 25 assertions, toutes passent
- Pint OK

## Action data en preprod / prod après merge

Les SubscriptionProducts existants avec `frequency = NULL` seront soignés automatiquement au prochain `ai-cad:sync-stripe`. Pas de migration de données nécessaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)