### PR TITLE
feat: webhook customer.subscription.trial_will_end → event TrialWillEnd

### DIFF
--- a/src/Events/TrialWillEnd.php
+++ b/src/Events/TrialWillEnd.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tolery\AiCad\Events;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tolery\AiCad\Models\ChatTeam;
+
+/**
+ * Fired when Stripe sends `customer.subscription.trial_will_end`,
+ * 3 days before the trial ends. Consumers can subscribe to send
+ * reminder emails or in-app notifications.
+ */
+class TrialWillEnd
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public ChatTeam $team,
+        public Carbon $trialEndsAt,
+    ) {}
+}

--- a/src/Http/Controllers/StripeWebhookController.php
+++ b/src/Http/Controllers/StripeWebhookController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\Subscription;
+use Tolery\AiCad\Events\TrialWillEnd;
 use Tolery\AiCad\Models\Chat;
 use Tolery\AiCad\Models\ChatDownload;
 use Tolery\AiCad\Models\ChatTeam;
@@ -326,6 +327,57 @@ class StripeWebhookController extends Controller
         ]);
 
         return response()->json(['success' => true], 200);
+    }
+
+    /**
+     * Handle customer.subscription.trial_will_end webhook.
+     *
+     * Stripe fires this event 3 days before the trial ends. We surface it as
+     * a `TrialWillEnd` Laravel event so consuming apps can react (e.g. send
+     * an email reminder).
+     */
+    protected function handleCustomerSubscriptionTrialWillEnd(array $payload): JsonResponse
+    {
+        try {
+            $subscription = $payload['object'];
+            $customerId = $subscription['customer'] ?? null;
+            $trialEnd = $subscription['trial_end'] ?? null;
+
+            if (! $customerId || ! $trialEnd) {
+                Log::warning('[AICAD Webhook] trial_will_end missing customer or trial_end', [
+                    'subscription_id' => $subscription['id'] ?? null,
+                ]);
+
+                return response()->json(['success' => true], 200);
+            }
+
+            $teamModel = config('ai-cad.chat_team_model', ChatTeam::class);
+            $team = $teamModel::where('tolerycad_stripe_id', $customerId)->first();
+
+            if (! $team) {
+                Log::warning('[AICAD Webhook] Team not found for trial_will_end', [
+                    'customer_id' => $customerId,
+                ]);
+
+                return response()->json(['success' => true], 200);
+            }
+
+            TrialWillEnd::dispatch($team, Carbon::createFromTimestamp($trialEnd));
+
+            Log::info('[AICAD Webhook] TrialWillEnd event dispatched', [
+                'team_id' => $team->id,
+                'trial_end' => $trialEnd,
+            ]);
+
+            return response()->json(['success' => true], 200);
+        } catch (\Exception $e) {
+            Log::error('[AICAD Webhook] Failed to handle customer.subscription.trial_will_end', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json(['success' => true], 200);
+        }
     }
 
     /**

--- a/tests/Feature/StripeWebhookTrialWillEndTest.php
+++ b/tests/Feature/StripeWebhookTrialWillEndTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Event;
+use Stripe\Event as StripeEvent;
+use Tolery\AiCad\Events\TrialWillEnd;
+use Tolery\AiCad\Models\ChatTeam;
+use Tolery\AiCad\Services\AiCadStripe;
+
+beforeEach(function () {
+    Event::fake();
+    config(['ai-cad.chat_team_model' => ChatTeam::class]);
+});
+
+function dispatchTrialWillEndWebhook(array $subscription): \Illuminate\Testing\TestResponse
+{
+    $stripeEvent = StripeEvent::constructFrom([
+        'id' => 'evt_trial_will_end_'.bin2hex(random_bytes(4)),
+        'object' => 'event',
+        'type' => 'customer.subscription.trial_will_end',
+        'data' => ['object' => $subscription],
+    ]);
+
+    test()->mock(AiCadStripe::class, function ($mock) use ($stripeEvent) {
+        $mock->shouldReceive('verifyWebhookSignature')->andReturn($stripeEvent);
+    });
+
+    return test()->postJson(
+        route('ai-cad.stripe.webhook'),
+        ['data' => ['object' => $subscription]],
+        ['Stripe-Signature' => 't=1,v1=fake'],
+    );
+}
+
+it('dispatches TrialWillEnd event when team is found', function () {
+    $team = ChatTeam::factory()->create([
+        'tolerycad_stripe_id' => 'cus_trial_team',
+    ]);
+
+    $trialEnd = Carbon::now()->addDays(3)->timestamp;
+
+    $response = dispatchTrialWillEndWebhook([
+        'id' => 'sub_test',
+        'customer' => 'cus_trial_team',
+        'trial_end' => $trialEnd,
+    ]);
+
+    $response->assertOk();
+
+    Event::assertDispatched(TrialWillEnd::class, function ($event) use ($team, $trialEnd) {
+        return $event->team->is($team)
+            && $event->trialEndsAt->timestamp === $trialEnd;
+    });
+});
+
+it('does not dispatch when no team matches the customer', function () {
+    $response = dispatchTrialWillEndWebhook([
+        'id' => 'sub_unknown',
+        'customer' => 'cus_does_not_exist',
+        'trial_end' => Carbon::now()->addDays(3)->timestamp,
+    ]);
+
+    $response->assertOk();
+
+    Event::assertNotDispatched(TrialWillEnd::class);
+});
+
+it('does not dispatch when trial_end is missing from payload', function () {
+    ChatTeam::factory()->create(['tolerycad_stripe_id' => 'cus_no_trial_end']);
+
+    $response = dispatchTrialWillEndWebhook([
+        'id' => 'sub_missing',
+        'customer' => 'cus_no_trial_end',
+        // trial_end omitted
+    ]);
+
+    $response->assertOk();
+
+    Event::assertNotDispatched(TrialWillEnd::class);
+});

--- a/tests/Feature/StripeWebhookTrialWillEndTest.php
+++ b/tests/Feature/StripeWebhookTrialWillEndTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Testing\TestResponse;
 use Stripe\Event as StripeEvent;
 use Tolery\AiCad\Events\TrialWillEnd;
 use Tolery\AiCad\Models\ChatTeam;
@@ -12,7 +13,7 @@ beforeEach(function () {
     config(['ai-cad.chat_team_model' => ChatTeam::class]);
 });
 
-function dispatchTrialWillEndWebhook(array $subscription): \Illuminate\Testing\TestResponse
+function dispatchTrialWillEndWebhook(array $subscription): TestResponse
 {
     $stripeEvent = StripeEvent::constructFrom([
         'id' => 'evt_trial_will_end_'.bin2hex(random_bytes(4)),


### PR DESCRIPTION
## Contexte

Stripe envoie automatiquement l'event `customer.subscription.trial_will_end` 3 jours avant la fin d'un trial. Le package n'avait pas de handler pour cet event.

## Changements

- Nouvel event Laravel `Tolery\AiCad\Events\TrialWillEnd` avec `ChatTeam $team` + `Carbon $trialEndsAt`
- `StripeWebhookController::handleCustomerSubscriptionTrialWillEnd` :
  - Récupère la team via `tolerycad_stripe_id`
  - Dispatch `TrialWillEnd` (laisse les apps consommatrices envoyer mail / notif / autre)
  - Retourne 200 dans tous les cas (Stripe ne réessaiera pas) avec logs warning si team introuvable
- 3 tests Pest couvrant : happy path, customer inconnu, trial_end manquant

## Pas de changement breaking

- Aucun fichier existant cassé. Si une app n'a pas de listener sur `TrialWillEnd`, le webhook est juste loggué et ignoré (comportement précédent : event-non-handled silencieux).

## Note de release

Ce PR est complémentaire de #148 (frequency NULL) — ils ne touchent pas les mêmes fichiers et peuvent être mergés indépendamment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)