### PR TITLE
fix: charger le quota avant l'early return sur ghost chat

### DIFF
--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -89,6 +89,12 @@ class Chatbot extends Component
 
     public function mount(): void
     {
+        // Load quota status before any early return so the chat header
+        // displays the progress bar even on a ghost chat (landing page).
+        /** @var ChatUser $user */
+        $user = auth()->user();
+        $this->quotaStatus = app(FileAccessService::class)->getQuotaStatus($user->team);
+
         // Si le chat n'existe pas encore (ghost chat), ne rien faire
         // Il sera créé au premier message envoyé
         if (! $this->chat->exists) {
@@ -127,11 +133,6 @@ class Chatbot extends Component
             // 4. Initialize download status
             $this->updateDownloadStatus();
         }
-
-        // Load quota status
-        /** @var ChatUser $user */
-        $user = auth()->user();
-        $this->quotaStatus = app(FileAccessService::class)->getQuotaStatus($user->team);
 
         // Charger les codes d'erreur DFM pour le mapping côté frontend
         $this->dfmErrorCodes = $this->loadDfmErrorCodes();


### PR DESCRIPTION
## Bug

Sur la page d'arrivée du chatbot (ghost chat, aucun message envoyé), la progress bar du quota n'apparaît jamais — y compris pour les abonnés actifs et les comptes trial.

## Cause

`Chatbot::mount()` ligne 94 fait un `return` quand le chat n'existe pas encore, **avant** la ligne 134 qui charge `$this->quotaStatus`. Conséquence : `quotaStatus` reste à `null`, donc le `@if ($quotaStatus)` du `chat-header` ne rend rien.

## Fix

Déplace le chargement de `quotaStatus` au tout début de `mount()`, avant n'importe quel early return. La progress bar est désormais visible dès la landing du chatbot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)