### PR TITLE
feat: enrich SSE stream failure diagnostics and retry on network blips

### DIFF
--- a/resources/views/livewire/chatbot.blade.php
+++ b/resources/views/livewire/chatbot.blade.php
@@ -360,7 +360,7 @@
                 const delay = this.retryDelays[this.retryCount] / 1000;
                 return `Nouvelle tentative dans ${delay}s... (${remaining} essai${remaining > 1 ? 's' : ''} restant${remaining > 1 ? 's' : ''})`;
             },
-            async notifyTeamOfFailure() {
+            async notifyTeamOfFailure(jsError = null) {
                 if (this.teamNotified) return;
 
                 aicadLog('[AICAD] 📧 Notifying Tolery team of repeated failure...');
@@ -370,6 +370,9 @@
                         sessionId: this.lastRequest.sessionId,
                         errorType: this.errorType,
                         errorMessage: this.errorMessage,
+                        jsErrorName: jsError?.name || jsError?.constructor?.name || 'N/A',
+                        jsErrorMessage: jsError?.message || 'N/A',
+                        jsErrorStack: jsError?.stack?.substring(0, 2000) || null,
                         retryCount: this.retryCount,
                     });
                     this.teamNotified = true;
@@ -648,16 +651,30 @@
                         return;
                     }
 
-                    // Retry disabled — go straight to error state
-                    // Logs and Nightwatch reporting are still active via reportStreamError above
-                    aicadError('[AICAD] ❌ Error — retry disabled, showing error to user');
+                    // Auto-retry once on transient network errors (Wi-Fi blip, tab backgrounded, etc.).
+                    // Other error types (auth, server, backend) go straight to user — they won't fix
+                    // themselves on a retry and we don't want to double-bill DFM on a genuine server issue.
+                    const NETWORK_RETRY_LIMIT = 1;
+                    if (errorInfo.canRetry && errorInfo.type === 'network' && this.retryCount < NETWORK_RETRY_LIMIT) {
+                        this.retryCount++;
+                        this.isRetrying = true;
+                        const delay = this.retryDelays[this.retryCount - 1] ?? 2000;
+                        this.statusText = `Nouvelle tentative dans ${Math.round(delay / 1000)}s...`;
+                        aicadLog(`[AICAD] 🔁 Auto-retrying after network error (attempt ${this.retryCount}/${NETWORK_RETRY_LIMIT}) in ${delay}ms...`);
+                        await new Promise(resolve => setTimeout(resolve, delay));
+                        await this.retryStream();
+                        return;
+                    }
+
+                    aicadError('[AICAD] ❌ Showing error to user (no further retry)');
 
                     this.hasError = true;
                     this.cancelable = true;
                     this.statusText = errorInfo.message;
 
-                    // Notify team via Nightwatch (without storing failure message in chat)
-                    await this.notifyTeamOfFailure();
+                    // Notify team via Nightwatch — pass the raw JS error so we can tell apart
+                    // client-side blips (TypeError: Failed to fetch) from server/proxy issues.
+                    await this.notifyTeamOfFailure(e);
 
                     window.dispatchEvent(new CustomEvent('cad-generation-ended'));
                 }

--- a/src/Http/Controllers/StreamController.php
+++ b/src/Http/Controllers/StreamController.php
@@ -82,6 +82,10 @@ class StreamController extends Controller
                 flush();
 
             } catch (\Exception $e) {
+                // Report to Nightwatch so we can distinguish server-side failures
+                // (CURL/API DFM down, non-200 response) from pure client-side network blips.
+                report($e);
+
                 Log::error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
                 Log::error('[AICAD] ❌ StreamController EXCEPTION');
                 Log::error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');

--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -1339,6 +1339,9 @@ class Chatbot extends Component
             'message_preview' => $data['message'] ?? 'N/A',
             'error_type' => $data['errorType'] ?? 'unknown',
             'error_message' => $data['errorMessage'] ?? 'N/A',
+            'js_error_name' => $data['jsErrorName'] ?? 'N/A',
+            'js_error_message' => $data['jsErrorMessage'] ?? 'N/A',
+            'js_error_stack' => $data['jsErrorStack'] ?? null,
             'retry_count' => $data['retryCount'] ?? 0,
             'timestamp' => now()->toIso8601String(),
             'environment' => app()->environment(),
@@ -1353,15 +1356,20 @@ class Chatbot extends Component
         Log::error('[AICAD] Session ID: '.($this->chat->session_id ?? 'N/A'));
         Log::error('[AICAD] Error Type: '.($data['errorType'] ?? 'unknown'));
         Log::error('[AICAD] Error Message: '.($data['errorMessage'] ?? 'N/A'));
+        Log::error('[AICAD] JS Error: '.($data['jsErrorName'] ?? 'N/A').' — '.($data['jsErrorMessage'] ?? 'N/A'));
         Log::error('[AICAD] Retry Count: '.($data['retryCount'] ?? 0));
         Log::error('[AICAD] Message Preview: '.($data['message'] ?? 'N/A'));
         Log::error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
 
-        // Report exception to Nightwatch / error tracker
+        // Report exception to Nightwatch / error tracker.
+        // The raw JS error name/message are included so we can tell apart
+        // "TypeError: Failed to fetch" (client network blip) from "Stream error: 504"
+        // (server / proxy timeout) directly in the Nightwatch issue title.
         report(new \RuntimeException(
             '[AICAD] Stream failure after '.$errorDetails['retry_count'].' retries — '
             .'Type: '.($data['errorType'] ?? 'unknown').' — '
             .'Message: '.($data['errorMessage'] ?? 'N/A').' — '
+            .'JS: '.($data['jsErrorName'] ?? 'N/A').': '.($data['jsErrorMessage'] ?? 'N/A').' — '
             .'User: '.$user->email.' — '
             .'Chat: '.$this->chat->id
         ));


### PR DESCRIPTION
## Contexte

On a régulièrement des erreurs `"Stream failure after 0 retries — Type: network — Message: Impossible de joindre le serveur"` dans Nightwatch sur le chatbot AICAD. Impossible aujourd'hui de distinguer :

- un vrai souci réseau côté navigateur user (Wi-Fi qui blink, onglet en sleep, etc.)
- un problème serveur Tolery → DFM (proxy timeout, 5xx, CSRF expiré, etc.)
- un crash côté API DFM

Toutes ces causes finissent reportées avec le **même** message générique, ce qui empêche Nam (dev DFM) et nous de trancher.

## Causes racines identifiées

1. **`StreamController` catch + Log::error sans `report()`** → les `RuntimeException` levées par `AICADClient` (qui contiennent `curl_errno`, `httpCode`, message cURL exact) **ne remontent pas à Nightwatch**.
2. **`notifyStreamFailure` ne transporte que le label classifié** → l'exception reportée à Nightwatch ne contient pas le vrai `e.name` / `e.message` JS qui permettrait de distinguer un `TypeError: Failed to fetch` d'un `Error: Stream error: 504`.
3. **Retry désactivé** (commenté dans le code, héritage d'une PR antérieure) → au moindre hoquet réseau côté client, échec direct affiché à l'user. Beaucoup d'erreurs Nightwatch viennent probablement de blips transitoires.

## Changements

| Fichier | Changement |
|---|---|
| `src/Http/Controllers/StreamController.php` | `report($e)` dans le `catch` → les exceptions de `AICADClient` (cURL fail, DFM non-200) atterrissent dans Nightwatch avec tout le détail |
| `src/Livewire/Chatbot.php` | `notifyStreamFailure()` accepte `jsErrorName`, `jsErrorMessage`, `jsErrorStack` et les inclut dans le titre de la `RuntimeException` reportée |
| `resources/views/livewire/chatbot.blade.php` | Auto-retry **1 fois** sur erreur `network` uniquement (autres types : pas de retry pour éviter le double-billing DFM sur un 5xx genuine) + passage de l'objet `Error` JS à `notifyTeamOfFailure()` |

## Effet attendu côté Nightwatch

**Avant** :
```
RuntimeException: [AICAD] Stream failure after 0 retries — Type: network —
Message: Impossible de joindre le serveur. Vérifiez votre connexion internet. —
User: x@y.io — Chat: 483
```

**Après** (selon la vraie cause) :
```
RuntimeException: [AICAD] Stream failure after 1 retries — Type: network —
Message: Impossible de joindre le serveur — JS: TypeError: Failed to fetch — User: ... — Chat: ...
```
ou
```
RuntimeException: [AICAD] Stream failure after 0 retries — Type: server —
Message: Le serveur de génération rencontre un problème temporaire —
JS: Error: Stream error: 504 Gateway Timeout — User: ... — Chat: ...
```
ou (côté serveur, nouveau !)
```
RuntimeException: SSE stream failed: Operation timed out after 600000 ms (Code: 28)
```

→ On saura **immédiatement** si la balle est dans notre camp ou celui de DFM.

## Limites / hors scope

Phase 1 = diagnostic uniquement. Le découplage backend complet (Job + Reverb broadcasting + persistance ChatMessage + notifications) arrive en Phase 2, dans une PR séparée.

## Test plan

- [ ] Merge + tag mineur (`v1.11.0`) + bump composer.json dans mn-tolery
- [ ] Déployer en preprod
- [ ] Reproduire une erreur (couper le Wi-Fi pendant une génération) → vérifier que :
  - [ ] 1 retry automatique a lieu après ~2s
  - [ ] Si l'erreur persiste, Nightwatch reçoit l'exception enrichie avec `JS: TypeError: ...`
- [ ] Sur une vraie erreur DFM, vérifier qu'on reçoit aussi l'exception `AICADClient` côté Nightwatch (avec `curl_errno`/`httpCode`)
- [ ] Surveiller pendant 48h le volume et la nouvelle ventilation des erreurs AICAD dans Nightwatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)