### PR TITLE
feat: auto-download piece after subscription checkout (#1895)

### DIFF
--- a/resources/views/livewire/chatbot.blade.php
+++ b/resources/views/livewire/chatbot.blade.php
@@ -689,6 +689,47 @@
         }
     });
 
+    // Auto-download après retour de Stripe Checkout (ticket #1895).
+    // Quand l'URL contient ?auto_download=1, on poll attemptAutoDownload() jusqu'à ce que
+    // le webhook Stripe ait synchronisé l'abonnement (max ~9s), puis on déclenche le DL.
+    (function autoDownloadAfterSubscription() {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('auto_download') !== '1') return;
+
+        // On retire le flag de l'URL pour éviter un re-trigger sur reload
+        params.delete('auto_download');
+        const cleanQuery = params.toString();
+        const cleanUrl = window.location.pathname + (cleanQuery ? '?' + cleanQuery : '');
+        window.history.replaceState({}, '', cleanUrl);
+
+        const MAX_ATTEMPTS = 6;     // 6 * 1500ms = 9s
+        const RETRY_DELAY_MS = 1500;
+        let attempts = 0;
+
+        const tryDownload = async () => {
+            attempts++;
+            aicadLog(`[AICAD] 🔁 Auto-download attempt ${attempts}/${MAX_ATTEMPTS}`);
+            try {
+                const ready = await $wire.attemptAutoDownload();
+                if (ready) {
+                    aicadLog('[AICAD] ✅ Auto-download triggered');
+                    return;
+                }
+            } catch (e) {
+                aicadError('[AICAD] Auto-download attempt failed:', e);
+            }
+
+            if (attempts < MAX_ATTEMPTS) {
+                setTimeout(tryDownload, RETRY_DELAY_MS);
+            } else {
+                aicadWarn('[AICAD] ⚠️ Auto-download gave up after max attempts (subscription webhook delay?)');
+            }
+        };
+
+        // Petit délai pour laisser Livewire finir son mount initial
+        setTimeout(tryDownload, 500);
+    })();
+
     // Listen for chat creation to update URL without redirecting
     Livewire.on('chat-created', ({chatId}) => {
         const newUrl = @js(route('client.tolerycad.show-chatbot', ['chat' => '__CHAT_ID__'])).replace('__CHAT_ID__', chatId);

--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -996,14 +996,48 @@ class Chatbot extends Component
     }
 
     /**
-     * Redirige vers la page de souscription d'abonnement
+     * Redirige vers la page de souscription d'abonnement.
+     *
+     * Stocke en session l'URL de retour vers le chat en cours, avec un flag
+     * `auto_download=1` qui déclenchera le téléchargement automatiquement après
+     * la fin du tunnel Stripe Checkout. Ticket #1895.
      */
     public function redirectToSubscription(): void
     {
         $this->showPurchaseModal = false;
 
-        // Rediriger vers la page de gestion d'abonnement ToleryCad
+        $returnUrl = route('client.tolerycad.show-chatbot', ['chat' => $this->chat]).'?auto_download=1';
+        session(['return_to_chatbot' => $returnUrl]);
+
         $this->redirect(route('client.tolerycad.subscription'));
+    }
+
+    /**
+     * Tente de déclencher le téléchargement automatiquement après retour de Stripe Checkout.
+     *
+     * Appelée par le polling JS au mount du composant quand l'URL contient `auto_download=1`.
+     * Renvoie true dès que le téléchargement est lancé (l'abonnement est actif côté DB),
+     * false tant que le webhook Stripe n'a pas encore synchronisé l'abonnement.
+     */
+    public function attemptAutoDownload(): bool
+    {
+        /** @var ChatUser|null $user */
+        $user = auth()->user();
+        $team = $user?->team;
+
+        if (! $team) {
+            return false;
+        }
+
+        $status = app(FileAccessService::class)->canDownloadChat($team, $this->chat);
+
+        if (! $status['can_download']) {
+            return false;
+        }
+
+        $this->initiateDownload();
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Closes [Tolery-Dev/mn-tolery#1895](https://github.com/Tolery-Dev/mn-tolery/issues/1895).

## Problème

Aujourd'hui, quand un utilisateur clique sur **Télécharger ma pièce** sans abonnement actif :
1. La modal d'abonnement s'affiche
2. Il clique **S'abonner** → redirigé vers la page abonnement générique
3. Tunnel Stripe Checkout
4. Au retour, il atterrit sur la page abonnement (`/client/tolerycad/subscription?success=1`)
5. Il doit re-naviguer vers son chat, re-cliquer sur **Télécharger**

→ Mauvaise UX, friction inutile entre conversion et résultat attendu.

## Solution

On exploite le mécanisme `session('return_to_chatbot')` qui existe déjà dans `ToleryCadSubscriptionController::index()` mais n'était jamais alimenté depuis le chatbot.

### Modifs

| Fichier | Changement |
|---|---|
| `src/Livewire/Chatbot.php::redirectToSubscription()` | Pose en session `return_to_chatbot` = URL du chat + `?auto_download=1` avant la redirection |
| `src/Livewire/Chatbot.php::attemptAutoDownload()` (nouveau) | Retourne `true` si l'abo est actif (et déclenche le DL via `initiateDownload()`), `false` sinon — pour le polling JS |
| `resources/views/livewire/chatbot.blade.php` | Au mount, si `?auto_download=1` dans l'URL : nettoie le param + poll `attemptAutoDownload()` 6× toutes les 1.5s (max ~9s) |

### Pourquoi un polling ?

Stripe peut renvoyer l'utilisateur sur `success_url` **avant** que le webhook `customer.subscription.created` ne soit traité. Pendant ce gap (qq secondes max), `FileAccessService::canDownloadChat()` retourne encore `false`. Le polling overbridge ce délai sans bloquer l'UI.

Si après 9s le webhook n'a toujours pas livré → on log un warning et on laisse l'user cliquer manuellement (qui marchera dès que le webhook arrive). Pas de toast bruyant — la grande majorité des cas se résoudront en <3s.

## Hors scope

- Pas de changement côté `mn-tolery` : le controller `index()` consomme déjà `session('return_to_chatbot')`
- Pas de change côté `purchase-modal.blade.php` : le bouton "S'abonner" appelle déjà `redirectToSubscription`

## Versioning

À tagger en `v1.12.0` après merge (feat mineur, rétrocompat).

## Test plan

- [ ] CI green (pint + tests existants)
- [ ] Preprod : créer un compte sans abo, lancer une génération, cliquer **Télécharger** → **S'abonner** → choisir un plan → compléter Stripe Checkout → vérifier qu'on revient bien sur le chat ET que le téléchargement se déclenche dans les ~3-5s
- [ ] Vérifier en console que le param `?auto_download=1` disparaît de l'URL après le polling
- [ ] Vérifier que si on reload la page après succès, le polling **ne se redéclenche pas** (param retiré de l'URL via `history.replaceState`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)