### PR TITLE
fix: parse last_seen_at defensively in completion notification

### DIFF
--- a/src/Notifications/CadGenerationCompletedNotification.php
+++ b/src/Notifications/CadGenerationCompletedNotification.php
@@ -25,14 +25,45 @@ class CadGenerationCompletedNotification extends Notification implements ShouldQ
     {
         $channels = ['database'];
 
-        $lastSeen = $notifiable->last_seen_at ?? null;
-        $isOnline = $lastSeen && $lastSeen->greaterThan(now()->subSeconds(30));
-
-        if (! $isOnline) {
+        if (! $this->isOnline($notifiable)) {
             $channels[] = 'mail';
         }
 
         return $channels;
+    }
+
+    /**
+     * Was the user active in the last 30 seconds?
+     *
+     * Defensive parsing: the consuming app's User model must add the column
+     * `last_seen_at` (populated by mn-tolery's TrackUserActivity middleware),
+     * but it isn't guaranteed to declare the `datetime` cast — in that case
+     * Eloquent hands us a raw string. We accept Carbon, string, or null.
+     */
+    protected function isOnline(mixed $notifiable): bool
+    {
+        $raw = $notifiable->last_seen_at ?? null;
+
+        if ($raw === null) {
+            return false;
+        }
+
+        $lastSeen = $raw instanceof \Carbon\CarbonInterface ? $raw : $this->parseTimestamp($raw);
+
+        return $lastSeen !== null && $lastSeen->greaterThan(now()->subSeconds(30));
+    }
+
+    protected function parseTimestamp(mixed $value): ?\Carbon\Carbon
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        try {
+            return \Carbon\Carbon::parse((string) $value);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     public function toMail(mixed $notifiable): MailMessage


### PR DESCRIPTION
Hotfix pour l'erreur prod **\`Call to a member function greaterThan() on string\`** levée par \`CadGenerationCompletedNotification::via()\` au moment où le Job tente d'envoyer la notification.

## Root cause

Le Job appelle \`Notification::send($message->user, ...)\` — \`\$user\` résout en \`ChatUser\` (modèle déclaré côté package). Côté mn-tolery, \`App\\Models\\User\` a bien le cast \`last_seen_at => 'datetime'\` (ajouté dans la PR #2169), mais \`ChatUser\` n'a pas ce cast — le package ne déclare pas cette colonne, c'est l'app qui l'ajoute. Eloquent renvoie alors la string brute de la DB, et \`->greaterThan(...)\` plante.

## Fix

Parsing défensif dans la notification : on accepte \`Carbon\`, string ou null. Si string → on parse en Carbon. Si parse rate ou null → user considéré offline (mail envoyé, comportement actuel avant la PR Phase 2).

Pas de changement de contrat côté consuming app — le package ne va pas dicter à l'app les casts d'une colonne que l'app a ajoutée elle-même.

## Versioning

À tagger **v1.15.1** après merge (patch, rétrocompat).

## Test plan

- [ ] CI green
- [ ] Tagger v1.15.1 + bump composer mn-tolery + MEPP/MEP
- [ ] Vérifier en prod qu'une nouvelle génération CAD termine sans plus lever cette exception
- [ ] Vérifier que le mail part toujours pour un user offline et est skip pour un user online (last_seen_at < 30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)