### PR TITLE
fix: replace 'do not close' warning with reassuring message

### DIFF
--- a/resources/views/livewire/partials/viewer-panel.blade.php
+++ b/resources/views/livewire/partials/viewer-panel.blade.php
@@ -95,15 +95,15 @@
                         </div>
                     </template>
 
-                    {{-- Avertissement (only when not in error state) --}}
+                    {{-- Info: la génération continue côté serveur même si l'onglet est fermé (Phase 2 / #152) --}}
                     <template x-if="!hasError">
-                        <div class="mt-6 p-4 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-3">
-                            <svg class="w-5 h-5 text-amber-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                        <div class="mt-6 p-4 bg-violet-50 border border-violet-200 rounded-lg flex items-start gap-3">
+                            <svg class="w-5 h-5 text-violet-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                             </svg>
                             <div class="flex-1">
-                                <p class="text-sm font-medium text-amber-900 mb-1">Ne fermez pas cette fenêtre</p>
-                                <p class="text-xs text-amber-700">La génération de votre pièce est en cours. Fermer cette fenêtre interrompra le processus.</p>
+                                <p class="text-sm font-medium text-violet-900 mb-1">Vous pouvez fermer cette fenêtre</p>
+                                <p class="text-xs text-violet-700">La génération continue en arrière-plan. Vous serez notifié dès que votre pièce sera prête.</p>
                             </div>
                         </div>
                     </template>


### PR DESCRIPTION
Depuis la Phase 2 async (#152, v1.14.0+), la génération continue côté worker même si l'onglet est fermé. Le warning ambré "Ne fermez pas cette fenêtre — fermer interrompra le processus" est factuellement incorrect et anxiogène.

Remplacé par un callout violet positif : *"Vous pouvez fermer cette fenêtre — la génération continue en arrière-plan. Vous serez notifié dès que votre pièce sera prête."*

À tagger en **v1.15.2** après merge (patch UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)