### PR TITLE
fix: guarantee completion notification reaches the user (supersedes #158)

### DIFF
--- a/resources/views/livewire/partials/viewer-panel.blade.php
+++ b/resources/views/livewire/partials/viewer-panel.blade.php
@@ -95,15 +95,17 @@
                         </div>
                     </template>
 
-                    {{-- Avertissement (only when not in error state) --}}
+                    {{-- Info: depuis Phase 2 (#152), la génération continue côté worker même si l'onglet ferme.
+                         La promesse de notification est tenue par SendCompletionEmailIfUnreadJob — cloche
+                         d'abord, email après 60s si l'user n'a pas vu la notif. --}}
                     <template x-if="!hasError">
-                        <div class="mt-6 p-4 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-3">
-                            <svg class="w-5 h-5 text-amber-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                        <div class="mt-6 p-4 bg-violet-50 border border-violet-200 rounded-lg flex items-start gap-3">
+                            <svg class="w-5 h-5 text-violet-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                             </svg>
                             <div class="flex-1">
-                                <p class="text-sm font-medium text-amber-900 mb-1">Ne fermez pas cette fenêtre</p>
-                                <p class="text-xs text-amber-700">La génération de votre pièce est en cours. Fermer cette fenêtre interrompra le processus.</p>
+                                <p class="text-sm font-medium text-violet-900 mb-1">Vous pouvez fermer cette fenêtre</p>
+                                <p class="text-xs text-violet-700">La génération continue en arrière-plan. Vous serez notifié dès que votre pièce sera prête.</p>
                             </div>
                         </div>
                     </template>

--- a/src/Jobs/GenerateCadJob.php
+++ b/src/Jobs/GenerateCadJob.php
@@ -116,7 +116,14 @@ class GenerateCadJob implements ShouldBeUnique, ShouldQueue
 
                     CadGenerationCompleted::dispatch($message);
 
+                    // Send the database (cloche) notification immediately. After 60s,
+                    // SendCompletionEmailIfUnreadJob checks whether it has been read;
+                    // if not, it dispatches the email so the user isn't left in the dark
+                    // (modal says "Vous serez notifié" — we keep that promise).
                     $this->notifyUser($message, new CadGenerationCompletedNotification($message));
+
+                    SendCompletionEmailIfUnreadJob::dispatch($message->id)
+                        ->delay(now()->addSeconds(60));
                 },
                 onError: function (int $curlErrno, int $httpCode, string $error) use ($message) {
                     $message->update([

--- a/src/Jobs/SendCompletionEmailIfUnreadJob.php
+++ b/src/Jobs/SendCompletionEmailIfUnreadJob.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tolery\AiCad\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+use Tolery\AiCad\Models\ChatMessage;
+use Tolery\AiCad\Notifications\CadGenerationCompletedNotification;
+
+/**
+ * Dispatched (with a delay) immediately after the database completion notification
+ * is sent. If the user hasn't read the cloche notification by the time this job
+ * runs, we send an email so the modal's "Vous serez notifié" promise is honored
+ * even when the user closed the tab right after seeing it.
+ *
+ * If the notification has already been read, this job is a no-op — no email spam
+ * for users who saw the cloche in time.
+ */
+class SendCompletionEmailIfUnreadJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public function __construct(public int $messageId) {}
+
+    public function handle(): void
+    {
+        $message = ChatMessage::find($this->messageId);
+
+        if (! $message) {
+            return;
+        }
+
+        $user = $message->user ?? $message->chat?->user;
+
+        if (! $user) {
+            return;
+        }
+
+        $unread = DatabaseNotification::query()
+            ->where('notifiable_type', $user::class)
+            ->where('notifiable_id', $user->getKey())
+            ->where('type', CadGenerationCompletedNotification::class)
+            ->whereJsonContains('data->message_id', $message->id)
+            ->whereNull('read_at')
+            ->exists();
+
+        if (! $unread) {
+            Log::info('[AICAD] Completion notification already read, skipping email', [
+                'message_id' => $message->id,
+            ]);
+
+            return;
+        }
+
+        Log::info('[AICAD] Completion notification unread after delay, sending email', [
+            'message_id' => $message->id,
+            'user_id' => $user->getKey(),
+        ]);
+
+        Notification::send($user, new CadGenerationCompletedNotification($message, ['mail']));
+    }
+}

--- a/src/Notifications/CadGenerationCompletedNotification.php
+++ b/src/Notifications/CadGenerationCompletedNotification.php
@@ -2,70 +2,37 @@
 
 namespace Tolery\AiCad\Notifications;
 
-use Carbon\Carbon;
-use Carbon\CarbonInterface;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Tolery\AiCad\Models\ChatMessage;
 
+/**
+ * Sent when a CAD generation finishes successfully.
+ *
+ * The channel set is normally `['database']` only — the SendCompletionEmailIfUnreadJob
+ * dispatches the same notification with `forceChannels = ['mail']` after a delay
+ * if the database notification hasn't been read yet. That ensures the modal's
+ * promise ("Vous serez notifié dès que votre pièce sera prête") is always
+ * honored, without spamming users who are still in the app and saw the cloche.
+ */
 class CadGenerationCompletedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public function __construct(public ChatMessage $message) {}
-
     /**
-     * Email is only sent when the user is unlikely to be looking at the app
-     * (last_seen_at older than 30s). Otherwise the Reverb event + the database
-     * notification (cloche) is enough — no need to spam the inbox.
-     *
-     * @return array<int, string>
+     * @param  array<int, string>|null  $forceChannels  Override the default channel set (e.g. ['mail'])
      */
+    public function __construct(
+        public ChatMessage $message,
+        public ?array $forceChannels = null,
+    ) {}
+
+    /** @return array<int, string> */
     public function via(mixed $notifiable): array
     {
-        $channels = ['database'];
-
-        if (! $this->isOnline($notifiable)) {
-            $channels[] = 'mail';
-        }
-
-        return $channels;
-    }
-
-    /**
-     * Was the user active in the last 30 seconds?
-     *
-     * Defensive parsing: the consuming app's User model must add the column
-     * `last_seen_at` (populated by mn-tolery's TrackUserActivity middleware),
-     * but it isn't guaranteed to declare the `datetime` cast — in that case
-     * Eloquent hands us a raw string. We accept Carbon, string, or null.
-     */
-    protected function isOnline(mixed $notifiable): bool
-    {
-        $raw = $notifiable->last_seen_at ?? null;
-
-        if ($raw === null) {
-            return false;
-        }
-
-        $lastSeen = $raw instanceof CarbonInterface ? $raw : $this->parseTimestamp($raw);
-
-        return $lastSeen !== null && $lastSeen->greaterThan(now()->subSeconds(30));
-    }
-
-    protected function parseTimestamp(mixed $value): ?Carbon
-    {
-        if (! is_string($value) && ! is_numeric($value)) {
-            return null;
-        }
-
-        try {
-            return Carbon::parse((string) $value);
-        } catch (\Throwable) {
-            return null;
-        }
+        return $this->forceChannels ?? ['database'];
     }
 
     public function toMail(mixed $notifiable): MailMessage


### PR DESCRIPTION
Supersede de [#158](https://github.com/Tolery-Dev/tolery-ai-cad-package/pull/158), fermée. La review adversariale Codex a relevé que la copy "Vous serez notifié" n'était pas garantie par le backend : un utilisateur qui ferme l'onglet **juste après** avoir lu le modal avait un \`last_seen_at\` < 30s, donc l'email était skip — et la cloche restait invisible vu que l'onglet était fermé.

## Solution

| Pièce | Rôle |
|---|---|
| \`CadGenerationCompletedNotification\` | \`via()\` retourne \`['database']\` par défaut. Constructor accepte \`?array \$forceChannels\` pour usage mail-only |
| \`SendCompletionEmailIfUnreadJob\` (nouveau) | Dispatch avec délai 60s après la notif DB. Check si la \`DatabaseNotification\` correspondante (matched par type + message_id + notifiable) a un \`read_at\`. Si non lue → envoie l'email. Si lue → no-op |
| \`viewer-panel.blade.php\` | Ambre "Ne fermez pas" → violet "Vous pouvez fermer cette fenêtre — vous serez notifié dès que votre pièce sera prête" |

## Pourquoi un délai plutôt qu'un mail systématique

L'idée initiale du check \`last_seen_at\` était d'éviter le spam pour les users actifs qui ont déjà vu la cloche. On garde cette propriété en lisant directement \`read_at\` dans la table \`notifications\` plutôt qu'en devinant via \`last_seen_at\` — plus précis et résilient à l'edge case "close tab immediately".

## Versioning

À tagger **v1.15.2** après merge.

## Test plan

- [ ] CI green
- [ ] En preprod : générer une pièce, **rester sur l'app** sans cliquer sur la cloche → la notif arrive en cloche, **pas d'email après 60s** si on a navigué (l'app marque-elle as read au render de la cloche ?)
- [ ] Générer une pièce, **fermer l'onglet immédiatement** → email reçu ~60s après
- [ ] Générer une pièce, **cliquer sur la cloche dans la minute** → \`read_at\` set → pas d'email

⚠️ **Pré-requis côté app mn-tolery** : que cliquer sur la cloche marque bien la notif comme \`read_at\` set. Si pas le cas, on enverra des emails même pour les users actifs. À confirmer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)