### PR TITLE
fix: notification delivery to consuming app's User + postgres-safe lookup

### DIFF
--- a/src/Jobs/SendCompletionEmailIfUnreadJob.php
+++ b/src/Jobs/SendCompletionEmailIfUnreadJob.php
@@ -41,11 +41,15 @@ class SendCompletionEmailIfUnreadJob implements ShouldQueue
             return;
         }
 
+        // The standard Laravel notifications table stores `data` as `text` (not
+        // jsonb) on PostgreSQL, so whereJsonContains can't use the JSON operator.
+        // We match on the serialized JSON string instead — `message_id` is an
+        // integer in the payload so the encoded form is stable.
         $unread = DatabaseNotification::query()
             ->where('notifiable_type', $user::class)
             ->where('notifiable_id', $user->getKey())
             ->where('type', CadGenerationCompletedNotification::class)
-            ->whereJsonContains('data->message_id', $message->id)
+            ->where('data', 'like', '%"message_id":'.$message->id.'%')
             ->whereNull('read_at')
             ->exists();
 

--- a/src/Models/ChatMessage.php
+++ b/src/Models/ChatMessage.php
@@ -65,11 +65,16 @@ class ChatMessage extends Model
     }
 
     /**
-     * @return BelongsTo<ChatUser, $this>
+     * @return BelongsTo<Model, $this>
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(ChatUser::class);
+        // Use the consuming app's User model when configured — only that model
+        // is guaranteed to carry the `Notifiable` trait. The package's bundled
+        // ChatUser is a minimal placeholder for tests / standalone use.
+        $userModel = config('ai-cad.chat_user_model') ?: ChatUser::class;
+
+        return $this->belongsTo($userModel, 'user_id');
     }
 
     public function getObjUrl(): ?string


### PR DESCRIPTION
Two end-to-end issues spotted en test local après #159 / v1.15.2 :

## 1) \`BadMethodCallException: ChatUser::routeNotificationFor*\`

\`ChatMessage::user()\` hard-codait le \`ChatUser\` bundled du package, qui extend \`Foundation\\Auth\\User\` et n'a pas le trait \`Notifiable\`. mn-tolery configure \`ai-cad.chat_user_model = App\\Models\\User\` (qui a Notifiable), mais la relation ignorait la config.

→ La relation lit maintenant \`config('ai-cad.chat_user_model')\` avec fallback sur \`ChatUser\` pour les tests / usage standalone.

## 2) \`SQLSTATE[42883]: operator does not exist: text\` dans \`SendCompletionEmailIfUnreadJob\`

La table Laravel \`notifications\` stocke \`data\` en \`text\` (pas \`jsonb\`) sur Postgres. \`whereJsonContains('data->message_id', ...)\` plante sur l'opérateur \`->\` qui n'existe pas sur du texte.

→ Bascule sur un LIKE string sur le JSON sérialisé. \`message_id\` est un int dans le payload donc le format encodé est stable.

## Versioning

À tagger **v1.15.3** après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)