### PR TITLE
chore: remove beforeunload reload protection (no longer needed since Phase 2)

### DIFF
--- a/resources/views/livewire/chatbot.blade.php
+++ b/resources/views/livewire/chatbot.blade.php
@@ -1,29 +1,4 @@
-<div class="relative h-screen flex flex-col bg-grey-background"
-     x-data="{
-         isGenerating: false,
-         init() {
-             // Écouter les événements de génération
-             window.addEventListener('cad-generation-started', () => {
-                 this.isGenerating = true;
-                 aicadLog('[RELOAD PROTECTION] Generation started, protection enabled');
-             });
-
-             window.addEventListener('cad-generation-ended', () => {
-                 this.isGenerating = false;
-                 aicadLog('[RELOAD PROTECTION] Generation ended, protection disabled');
-             });
-
-             // Protection contre le reload/fermeture pendant la génération
-             window.addEventListener('beforeunload', (e) => {
-                 if (this.isGenerating) {
-                     aicadLog('[RELOAD PROTECTION] Blocking reload/close attempt');
-                     e.preventDefault();
-                     e.returnValue = ''; // Chrome nécessite returnValue
-                     return ''; // Firefox/Safari
-                 }
-             });
-         }
-     }">
+<div class="relative h-screen flex flex-col bg-grey-background">
 
     @include('ai-cad::livewire.partials.chat-header')
 


### PR DESCRIPTION
Depuis Phase 2 (#152, v1.14.0+), la génération CAD tourne sur le queue worker \`tolerycad-long\` et survit au close/reload. Le dialog "Are you sure you want to leave?" avait du sens avant ; maintenant il est carrément trompeur.

## Changes

- \`chatbot.blade.php\` : retire le root \`x-data\` qui maintenait \`isGenerating\` + l'event listener \`beforeunload\`. Les autres scopes Alpine internes gardent leurs propres watchers \`@cad-generation-{started,ended}.window\` pour leur UX locale.

À tagger **v1.15.4** après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)