### PR TITLE
Add Stripe product catalog management and trial subscription tracking

### DIFF
--- a/config/ai-cad.php
+++ b/config/ai-cad.php
@@ -70,6 +70,7 @@ return [
                     ['name' => 'Dashboard', 'route' => 'ai-cad.admin.dashboard'],
                     ['name' => 'Conversations', 'route' => 'ai-cad.admin.chats.index'],
                     ['name' => 'Achats', 'route' => 'ai-cad.admin.purchases.index'],
+                    ['name' => 'Produits Stripe', 'route' => 'ai-cad.admin.products.index'],
                     ['name' => 'Téléchargements', 'route' => 'ai-cad.admin.downloads.index'],
                     ['name' => 'Prompts', 'route' => 'ai-cad.admin.prompts.index'],
                 ],

--- a/database/migrations/2026_05_19_000000_add_image_url_to_subscription_products_table.php
+++ b/database/migrations/2026_05_19_000000_add_image_url_to_subscription_products_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('subscription_products', function (Blueprint $table) {
+            $table->string('image_url')->nullable()->after('description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('subscription_products', function (Blueprint $table) {
+            $table->dropColumn('image_url');
+        });
+    }
+};

--- a/resources/views/admin/products/index.blade.php
+++ b/resources/views/admin/products/index.blade.php
@@ -1,0 +1,7 @@
+<x-layout.app>
+    <x-slot:title returnUrl="{{ route('ai-cad.admin.dashboard') }}">
+        ToleryCad - Produits Stripe
+    </x-slot>
+
+    <livewire:ai-cad-admin-subscription-product-table />
+</x-layout.app>

--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -49,6 +49,13 @@
         <flux:card class="bg-purple-50 dark:bg-purple-900/20">
             <flux:heading level="3" size="sm">Total abonnés</flux:heading>
             <div class="mt-2 text-3xl font-bold text-purple-600 dark:text-purple-400">{{ $kpis['subscription_count'] }}</div>
+            <flux:text class="text-sm text-gray-500 mt-1">actifs et essais inclus</flux:text>
+        </flux:card>
+
+        <flux:card class="bg-amber-50 dark:bg-amber-900/20">
+            <flux:heading level="3" size="sm">Essais gratuits en cours</flux:heading>
+            <div class="mt-2 text-3xl font-bold text-amber-600 dark:text-amber-400">{{ $kpis['trialing_count'] }}</div>
+            <flux:text class="text-sm text-gray-500 mt-1">compte(s) en période d'essai</flux:text>
         </flux:card>
 
         @forelse ($kpis['subscriptions_by_product'] as $productName => $count)
@@ -62,6 +69,51 @@
                 <flux:text class="text-gray-500">Aucun abonnement actif</flux:text>
             </flux:card>
         @endforelse
+    </div>
+
+    {{-- Comptes en essai gratuit --}}
+    <flux:heading level="2" size="lg" class="mb-4">Comptes en essai gratuit</flux:heading>
+    <div class="mb-8 overflow-hidden rounded-xl border border-gray-100 dark:border-gray-700">
+        @if ($trialingSubscriptions->isEmpty())
+            <div class="p-6">
+                <flux:text class="text-gray-500">Aucun compte en essai gratuit actuellement.</flux:text>
+            </div>
+        @else
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-gray-100 text-left text-gray-500 dark:border-gray-700">
+                            <th class="px-4 py-3 font-medium">Équipe</th>
+                            <th class="px-4 py-3 font-medium">Produit</th>
+                            <th class="px-4 py-3 font-medium">Début d'essai</th>
+                            <th class="px-4 py-3 font-medium">Fin d'essai</th>
+                            <th class="px-4 py-3 font-medium">Jours restants</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($trialingSubscriptions as $trial)
+                            <tr class="border-b border-gray-50 last:border-0 dark:border-gray-800">
+                                <td class="px-4 py-3 font-medium">{{ $trial['team_name'] }}</td>
+                                <td class="px-4 py-3">{{ $trial['product_name'] }}</td>
+                                <td class="px-4 py-3 text-gray-500">{{ $trial['started_at']?->format('d/m/Y') ?? '-' }}</td>
+                                <td class="px-4 py-3 text-gray-500">{{ $trial['trial_ends_at']?->format('d/m/Y') ?? '-' }}</td>
+                                <td class="px-4 py-3">
+                                    @if ($trial['days_left'] === null)
+                                        <span class="text-gray-400">-</span>
+                                    @elseif ($trial['days_left'] < 0)
+                                        <flux:badge size="sm" color="red">Expiré</flux:badge>
+                                    @else
+                                        <flux:badge size="sm" color="{{ $trial['days_left'] <= 3 ? 'amber' : 'green' }}">
+                                            {{ $trial['days_left'] }} jour(s)
+                                        </flux:badge>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
     </div>
 
     {{-- Activity KPIs --}}
@@ -90,6 +142,10 @@
         <flux:button href="{{ route('ai-cad.admin.chats.index') }}" variant="outline" class="justify-start">
             <flux:icon name="chat-bubble-left-right" class="mr-2" />
             Voir les conversations
+        </flux:button>
+        <flux:button href="{{ route('ai-cad.admin.products.index') }}" variant="outline" class="justify-start">
+            <flux:icon name="cube" class="mr-2" />
+            Produits Stripe
         </flux:button>
         <flux:button href="{{ route('ai-cad.admin.downloads.index') }}" variant="outline" class="justify-start">
             <flux:icon name="arrow-down-tray" class="mr-2" />

--- a/resources/views/livewire/admin/subscription-product-table.blade.php
+++ b/resources/views/livewire/admin/subscription-product-table.blade.php
@@ -1,0 +1,97 @@
+<div>
+    {{-- Header --}}
+    <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <flux:heading level="1" size="xl">Produits Stripe</flux:heading>
+            <flux:text class="text-gray-500">Catalogue Stripe et synchronisation sur la plateforme</flux:text>
+        </div>
+        <flux:button
+            wire:click="sync"
+            wire:loading.attr="disabled"
+            wire:target="sync"
+            variant="primary"
+            icon="arrow-path"
+        >
+            <span wire:loading.remove wire:target="sync">Synchroniser</span>
+            <span wire:loading wire:target="sync">Synchronisation…</span>
+        </flux:button>
+    </div>
+
+    {{-- Sync result --}}
+    @if ($syncMessage)
+        <div class="mb-6 rounded-lg border p-4 text-sm {{ $syncStatus === 'success' ? 'border-green-200 bg-green-50 text-green-800 dark:border-green-900 dark:bg-green-900/20 dark:text-green-300' : 'border-red-200 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300' }}">
+            {{ $syncMessage }}
+        </div>
+    @endif
+
+    @php($catalog = $this->catalog)
+
+    @if ($catalog['error'])
+        <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300">
+            Impossible de récupérer le catalogue Stripe : {{ $catalog['error'] }}
+        </div>
+    @elseif (empty($catalog['products']))
+        <flux:card>
+            <flux:text class="text-gray-500">Aucun produit dans le catalogue Stripe.</flux:text>
+        </flux:card>
+    @else
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            @foreach ($catalog['products'] as $product)
+                <flux:card class="flex flex-col">
+                    {{-- Product image --}}
+                    <div class="mb-4 flex h-40 items-center justify-center overflow-hidden rounded-lg bg-gray-50 dark:bg-gray-800">
+                        @if ($product['image'])
+                            <img src="{{ $product['image'] }}" alt="{{ $product['name'] }}" class="h-full w-full object-contain" />
+                        @else
+                            <flux:icon name="photo" class="h-10 w-10 text-gray-300" />
+                        @endif
+                    </div>
+
+                    {{-- Name + Stripe status --}}
+                    <div class="mb-2 flex items-start justify-between gap-2">
+                        <flux:heading level="3" size="sm">{{ $product['name'] }}</flux:heading>
+                        @if ($product['active'])
+                            <flux:badge size="sm" color="green">Actif</flux:badge>
+                        @else
+                            <flux:badge size="sm" color="zinc">Inactif</flux:badge>
+                        @endif
+                    </div>
+
+                    {{-- Description --}}
+                    <flux:text class="mb-3 line-clamp-3 text-sm text-gray-500">
+                        {{ $product['description'] ?: 'Aucune description' }}
+                    </flux:text>
+
+                    {{-- Prices --}}
+                    <div class="mb-3 space-y-1">
+                        @forelse ($product['prices'] as $price)
+                            <div class="text-sm font-medium">
+                                {{ $price['formatted'] }}
+                                <span class="text-gray-400">/ {{ $price['interval_label'] }}</span>
+                            </div>
+                        @empty
+                            <flux:text class="text-sm text-gray-400">Aucun prix récurrent</flux:text>
+                        @endforelse
+                    </div>
+
+                    {{-- Sync status --}}
+                    <div class="mt-auto border-t border-gray-100 pt-3 dark:border-gray-700">
+                        @if (! $product['synced'])
+                            <flux:badge size="sm" color="zinc">Non synchronisé</flux:badge>
+                        @elseif ($product['out_of_sync'])
+                            <flux:badge size="sm" color="amber">À mettre à jour</flux:badge>
+                        @else
+                            <flux:badge size="sm" color="green">Synchronisé</flux:badge>
+                        @endif
+
+                        @if ($product['last_synced_at'])
+                            <flux:text class="mt-1 text-xs text-gray-400">
+                                Dernière synchro : {{ $product['last_synced_at']->format('d/m/Y H:i') }}
+                            </flux:text>
+                        @endif
+                    </div>
+                </flux:card>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -8,6 +8,7 @@ use Tolery\AiCad\Http\Controllers\Admin\DownloadController;
 use Tolery\AiCad\Http\Controllers\Admin\FilePurchaseController;
 use Tolery\AiCad\Http\Controllers\Admin\PredefinedPromptController;
 use Tolery\AiCad\Http\Controllers\Admin\StepMessageController;
+use Tolery\AiCad\Http\Controllers\Admin\SubscriptionProductController;
 
 /*
 |--------------------------------------------------------------------------
@@ -38,6 +39,9 @@ Route::middleware(config('ai-cad.admin.middleware', ['web', 'auth', 'admin']))
 
         // File Purchases
         Route::get('/purchases', [FilePurchaseController::class, 'index'])->name('purchases.index');
+
+        // Subscription Products (Stripe catalog)
+        Route::get('/products', [SubscriptionProductController::class, 'index'])->name('products.index');
 
         // Downloads
         Route::get('/downloads', [ChatDownloadController::class, 'index'])->name('downloads.index');

--- a/src/AiCadServiceProvider.php
+++ b/src/AiCadServiceProvider.php
@@ -27,6 +27,7 @@ use Tolery\AiCad\Livewire\Admin\PredefinedPromptForm;
 use Tolery\AiCad\Livewire\Admin\PredefinedPromptTable;
 use Tolery\AiCad\Livewire\Admin\StepMessageForm;
 use Tolery\AiCad\Livewire\Admin\StepMessageTable;
+use Tolery\AiCad\Livewire\Admin\SubscriptionProductTable;
 use Tolery\AiCad\Livewire\Chatbot;
 use Tolery\AiCad\Livewire\ChatConfig;
 use Tolery\AiCad\Livewire\ChatHistoryPanel;
@@ -142,6 +143,7 @@ class AiCadServiceProvider extends PackageServiceProvider
             Livewire::component('ai-cad-admin-predefined-prompt-form', PredefinedPromptForm::class);
             Livewire::component('ai-cad-admin-step-message-table', StepMessageTable::class);
             Livewire::component('ai-cad-admin-step-message-form', StepMessageForm::class);
+            Livewire::component('ai-cad-admin-subscription-product-table', SubscriptionProductTable::class);
         });
 
         return $this;

--- a/src/Http/Controllers/Admin/SubscriptionProductController.php
+++ b/src/Http/Controllers/Admin/SubscriptionProductController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tolery\AiCad\Http\Controllers\Admin;
+
+use Illuminate\View\View;
+
+class SubscriptionProductController
+{
+    public function index(): View
+    {
+        return view('ai-cad::admin.products.index');
+    }
+}

--- a/src/Livewire/Admin/Dashboard.php
+++ b/src/Livewire/Admin/Dashboard.php
@@ -4,12 +4,15 @@ namespace Tolery\AiCad\Livewire\Admin;
 
 use Composer\InstalledVersions;
 use Flux\DateRange;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\View\View;
 use Laravel\Cashier\Subscription;
 use Laravel\Cashier\SubscriptionItem;
 use Livewire\Component;
 use Tolery\AiCad\Models\Chat;
 use Tolery\AiCad\Models\ChatDownload;
+use Tolery\AiCad\Models\ChatTeam;
 use Tolery\AiCad\Models\FilePurchase;
 use Tolery\AiCad\Models\SubscriptionPrice;
 use Tolery\AiCad\Models\SubscriptionProduct;
@@ -32,6 +35,7 @@ class Dashboard extends Component
      *     conversation_count: int,
      *     download_count: int,
      *     subscription_count: int,
+     *     trialing_count: int,
      *     subscriptions_by_product: array<string, int>
      * }
      */
@@ -112,14 +116,59 @@ class Dashboard extends Component
             'conversation_count' => $chatQuery->count(),
             'download_count' => $downloadQuery->count(),
             'subscription_count' => $activeSubscriptions->count(),
+            'trialing_count' => $activeSubscriptions->where('stripe_status', 'trialing')->count(),
             'subscriptions_by_product' => $subscriptionsByProduct,
         ];
+    }
+
+    /**
+     * Teams currently on a free trial, paired with their plan and trial end date.
+     *
+     * @return Collection<int, array{team_name: string, product_name: string, trial_ends_at: ?Carbon, started_at: ?Carbon, days_left: ?int}>
+     */
+    public function getTrialingSubscriptions(): Collection
+    {
+        $subscriptions = Subscription::query()
+            ->where('type', 'default')
+            ->where('stripe_status', 'trialing')
+            ->with('items')
+            ->orderBy('trial_ends_at')
+            ->get();
+
+        /** @var Collection<int, ChatTeam> $teams */
+        $teams = ChatTeam::query()
+            ->whereIn('id', $subscriptions->pluck('team_id')->filter()->unique()->all())
+            ->get()
+            ->keyBy('id');
+
+        return $subscriptions->map(function (Subscription $subscription) use ($teams): array {
+            /** @var SubscriptionItem|null $item */
+            $item = $subscription->items->first();
+
+            $product = $item !== null
+                /** @phpstan-ignore-next-line - stripe_product is a dynamic attribute from Cashier */
+                ? SubscriptionProduct::where('stripe_id', $item->stripe_product)->first()
+                : null;
+
+            $trialEndsAt = $subscription->trial_ends_at;
+
+            return [
+                'team_name' => $teams->get($subscription->team_id)?->name ?? 'Inconnu',
+                'product_name' => $product?->name ?? 'Inconnu',
+                'trial_ends_at' => $trialEndsAt,
+                'started_at' => $subscription->created_at,
+                'days_left' => $trialEndsAt !== null
+                    ? (int) now()->startOfDay()->diffInDays($trialEndsAt->copy()->startOfDay(), false)
+                    : null,
+            ];
+        });
     }
 
     public function render(): View
     {
         return view('ai-cad::livewire.admin.dashboard', [
             'kpis' => $this->getKpis(),
+            'trialingSubscriptions' => $this->getTrialingSubscriptions(),
             'version' => InstalledVersions::getPrettyVersion('tolery/ai-cad') ?? 'dev',
         ]);
     }

--- a/src/Livewire/Admin/Dashboard.php
+++ b/src/Livewire/Admin/Dashboard.php
@@ -124,7 +124,7 @@ class Dashboard extends Component
     /**
      * Teams currently on a free trial, paired with their plan and trial end date.
      *
-     * @return Collection<int, array{team_name: string, product_name: string, trial_ends_at: ?Carbon, started_at: ?Carbon, days_left: ?int}>
+     * Each row: array{team_name: string, product_name: string, trial_ends_at: ?Carbon, started_at: ?Carbon, days_left: ?int}
      */
     public function getTrialingSubscriptions(): Collection
     {
@@ -135,33 +135,42 @@ class Dashboard extends Component
             ->orderBy('trial_ends_at')
             ->get();
 
-        /** @var Collection<int, ChatTeam> $teams */
-        $teams = ChatTeam::query()
+        /** @var array<int, string> $teamNames */
+        $teamNames = ChatTeam::query()
             ->whereIn('id', $subscriptions->pluck('team_id')->filter()->unique()->all())
-            ->get()
-            ->keyBy('id');
+            ->pluck('name', 'id')
+            ->all();
 
-        return $subscriptions->map(function (Subscription $subscription) use ($teams): array {
-            /** @var SubscriptionItem|null $item */
-            $item = $subscription->items->first();
+        /** @var array<string, string> $productNames */
+        $productNames = SubscriptionProduct::query()
+            ->pluck('name', 'stripe_id')
+            ->all();
 
-            $product = $item !== null
-                /** @phpstan-ignore-next-line - stripe_product is a dynamic attribute from Cashier */
-                ? SubscriptionProduct::where('stripe_id', $item->stripe_product)->first()
-                : null;
+        $rows = [];
 
-            $trialEndsAt = $subscription->trial_ends_at;
+        foreach ($subscriptions as $subscription) {
+            $teamId = (int) $subscription->getAttribute('team_id');
 
-            return [
-                'team_name' => $teams->get($subscription->team_id)?->name ?? 'Inconnu',
-                'product_name' => $product?->name ?? 'Inconnu',
+            $firstItem = $subscription->items->first();
+            $stripeProductId = (string) $firstItem?->getAttribute('stripe_product');
+
+            /** @var Carbon|null $trialEndsAt */
+            $trialEndsAt = $subscription->getAttribute('trial_ends_at');
+            /** @var Carbon|null $startedAt */
+            $startedAt = $subscription->getAttribute('created_at');
+
+            $rows[] = [
+                'team_name' => $teamNames[$teamId] ?? 'Inconnu',
+                'product_name' => $productNames[$stripeProductId] ?? 'Inconnu',
                 'trial_ends_at' => $trialEndsAt,
-                'started_at' => $subscription->created_at,
+                'started_at' => $startedAt,
                 'days_left' => $trialEndsAt !== null
                     ? (int) now()->startOfDay()->diffInDays($trialEndsAt->copy()->startOfDay(), false)
                     : null,
             ];
-        });
+        }
+
+        return collect($rows);
     }
 
     public function render(): View

--- a/src/Livewire/Admin/SubscriptionProductTable.php
+++ b/src/Livewire/Admin/SubscriptionProductTable.php
@@ -71,8 +71,12 @@ class SubscriptionProductTable extends Component
 
         $products = [];
 
-        foreach ($stripeProducts->data as $stripeProduct) {
+        /** @var array<int, Product> $stripeProductList */
+        $stripeProductList = $stripeProducts->data;
+
+        foreach ($stripeProductList as $stripeProduct) {
             try {
+                /** @var array<int, Price> $prices */
                 $prices = $aiCadStripe->listPrices($stripeProduct->id)->data;
             } catch (\Throwable $e) {
                 $prices = [];

--- a/src/Livewire/Admin/SubscriptionProductTable.php
+++ b/src/Livewire/Admin/SubscriptionProductTable.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tolery\AiCad\Livewire\Admin;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Number;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+use Stripe\Exception\ApiErrorException;
+use Stripe\Price;
+use Stripe\Product;
+use Tolery\AiCad\Models\SubscriptionProduct;
+use Tolery\AiCad\Services\AiCadStripe;
+use Tolery\AiCad\Services\StripeSyncService;
+
+class SubscriptionProductTable extends Component
+{
+    public ?string $syncMessage = null;
+
+    /** @var 'success'|'error'|null */
+    public ?string $syncStatus = null;
+
+    public function sync(StripeSyncService $syncService): void
+    {
+        try {
+            $result = $syncService->syncProductsFromStripe();
+
+            $message = "{$result['products']} produit(s) et {$result['prices']} prix synchronisés.";
+
+            if (! empty($result['deleted_products'])) {
+                $message .= " {$result['deleted_products']} produit(s) obsolète(s) supprimé(s).";
+            }
+
+            if (! empty($result['errors'])) {
+                $this->syncStatus = 'error';
+                $this->syncMessage = $message.' Erreurs : '.implode(' ; ', $result['errors']);
+            } else {
+                $this->syncStatus = 'success';
+                $this->syncMessage = $message;
+            }
+        } catch (ApiErrorException $e) {
+            $this->syncStatus = 'error';
+            $this->syncMessage = 'Erreur API Stripe : '.$e->getMessage();
+        } catch (\Throwable $e) {
+            $this->syncStatus = 'error';
+            $this->syncMessage = 'Erreur : '.$e->getMessage();
+        }
+
+        unset($this->catalog);
+    }
+
+    /**
+     * Live Stripe catalogue paired with the locally synced products.
+     *
+     * @return array{products: array<int, array<string, mixed>>, error: ?string}
+     */
+    #[Computed]
+    public function catalog(): array
+    {
+        $aiCadStripe = app(AiCadStripe::class);
+
+        try {
+            $stripeProducts = $aiCadStripe->listProducts();
+        } catch (\Throwable $e) {
+            return ['products' => [], 'error' => $e->getMessage()];
+        }
+
+        /** @var Collection<string, SubscriptionProduct> $localProducts */
+        $localProducts = SubscriptionProduct::query()->get()->keyBy('stripe_id');
+
+        $products = [];
+
+        foreach ($stripeProducts->data as $stripeProduct) {
+            try {
+                $prices = $aiCadStripe->listPrices($stripeProduct->id)->data;
+            } catch (\Throwable $e) {
+                $prices = [];
+            }
+
+            $local = $localProducts->get($stripeProduct->id);
+            $images = $stripeProduct->images ?? [];
+
+            $products[] = [
+                'id' => $stripeProduct->id,
+                'name' => $stripeProduct->name,
+                'description' => $stripeProduct->description,
+                'image' => ! empty($images) ? $images[0] : null,
+                'active' => (bool) $stripeProduct->active,
+                'prices' => $this->mapPrices($prices),
+                'synced' => $local !== null,
+                'out_of_sync' => $local !== null && $this->productOutOfSync($stripeProduct, $local),
+                'last_synced_at' => $local?->updated_at,
+            ];
+        }
+
+        return ['products' => $products, 'error' => null];
+    }
+
+    /**
+     * @param  array<int, Price>  $prices
+     * @return array<int, array{formatted: string, interval_label: string}>
+     */
+    protected function mapPrices(array $prices): array
+    {
+        $intervalLabels = [
+            'day' => 'jour',
+            'week' => 'semaine',
+            'month' => 'mois',
+            'year' => 'an',
+        ];
+
+        $mapped = [];
+
+        foreach ($prices as $price) {
+            if ($price->type !== 'recurring' || $price->recurring === null) {
+                continue;
+            }
+
+            $interval = $price->recurring->interval;
+
+            $mapped[] = [
+                'formatted' => Number::currency(
+                    ($price->unit_amount ?? 0) / 100,
+                    strtoupper($price->currency),
+                    'fr',
+                ),
+                'interval_label' => $intervalLabels[$interval] ?? $interval,
+            ];
+        }
+
+        return $mapped;
+    }
+
+    protected function productOutOfSync(Product $stripeProduct, SubscriptionProduct $local): bool
+    {
+        $images = $stripeProduct->images ?? [];
+        $stripeImage = ! empty($images) ? $images[0] : null;
+
+        return $local->name !== $stripeProduct->name
+            || (string) $local->description !== (string) ($stripeProduct->description ?? '')
+            || $local->image_url !== $stripeImage
+            || $local->active !== (bool) $stripeProduct->active;
+    }
+
+    public function render(): View
+    {
+        return view('ai-cad::livewire.admin.subscription-product-table');
+    }
+}

--- a/src/Models/SubscriptionProduct.php
+++ b/src/Models/SubscriptionProduct.php
@@ -17,6 +17,7 @@ use Tolery\AiCad\Observers\SubscriptionProductObserver;
  * @property int $id
  * @property string $name
  * @property string $description
+ * @property ?string $image_url
  * @property int $price
  * @property bool $active
  * @property int $files_allowed
@@ -36,6 +37,7 @@ class SubscriptionProduct extends Model
         'stripe_id',
         'name',
         'description',
+        'image_url',
         'files_allowed',
         'active',
         'frequency',

--- a/src/Models/SubscriptionProduct.php
+++ b/src/Models/SubscriptionProduct.php
@@ -2,6 +2,7 @@
 
 namespace Tolery\AiCad\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -24,6 +25,8 @@ use Tolery\AiCad\Observers\SubscriptionProductObserver;
  * @property string $stripe_id
  * @property string $stripe_price_id
  * @property ResetFrequency|null $frequency
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property-read Collection<int, SubscriptionPrice> $prices
  * @property-read ?SubscriptionPrice $activeMonthlyPrice
  * @property-read ?SubscriptionPrice $activeYearlyPrice

--- a/src/Services/StripeSyncService.php
+++ b/src/Services/StripeSyncService.php
@@ -79,8 +79,11 @@ class StripeSyncService
 
         $product = SubscriptionProduct::firstOrNew(['stripe_id' => $stripeProduct->id]);
 
+        $images = $stripeProduct->images ?? [];
+
         $product->name = $stripeProduct->name;
         $product->description = $stripeProduct->description ?? '';
+        $product->image_url = ! empty($images) ? $images[0] : null;
         $product->active = $stripeProduct->active;
         $product->files_allowed = $filesAllowed ? (int) $filesAllowed : null;
 

--- a/tests/Feature/DashboardTrialSubscriptionsTest.php
+++ b/tests/Feature/DashboardTrialSubscriptionsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Laravel\Cashier\Subscription;
+use Laravel\Cashier\SubscriptionItem;
+use Tolery\AiCad\Livewire\Admin\Dashboard;
+use Tolery\AiCad\Models\ChatTeam;
+use Tolery\AiCad\Models\SubscriptionProduct;
+
+beforeEach(function () {
+    config(['ai-cad.chat_team_model' => ChatTeam::class]);
+});
+
+function createSubscriptionRecord(array $attributes): Subscription
+{
+    $subscription = new Subscription;
+    $subscription->forceFill($attributes)->save();
+
+    return $subscription;
+}
+
+it('collects subscriptions currently on a free trial', function () {
+    $team = ChatTeam::factory()->create(['name' => 'Acme Corp']);
+    SubscriptionProduct::factory()->create([
+        'stripe_id' => 'prod_pro',
+        'name' => 'Plan Pro',
+    ]);
+
+    $subscription = createSubscriptionRecord([
+        'team_id' => $team->id,
+        'type' => 'default',
+        'stripe_id' => 'sub_trial_1',
+        'stripe_status' => 'trialing',
+        'stripe_price' => 'price_pro',
+        'quantity' => 1,
+        'trial_ends_at' => now()->addDays(10),
+    ]);
+
+    (new SubscriptionItem)->forceFill([
+        'subscription_id' => $subscription->id,
+        'stripe_id' => 'si_trial_1',
+        'stripe_product' => 'prod_pro',
+        'stripe_price' => 'price_pro',
+        'quantity' => 1,
+    ])->save();
+
+    $trials = (new Dashboard)->getTrialingSubscriptions();
+
+    expect($trials)->toHaveCount(1);
+
+    $first = $trials->first();
+    expect($first['team_name'])->toBe('Acme Corp')
+        ->and($first['product_name'])->toBe('Plan Pro')
+        ->and($first['days_left'])->toBeGreaterThan(0);
+});
+
+it('excludes active (non-trial) subscriptions from the trial list', function () {
+    $team = ChatTeam::factory()->create();
+
+    createSubscriptionRecord([
+        'team_id' => $team->id,
+        'type' => 'default',
+        'stripe_id' => 'sub_active_1',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_pro',
+        'quantity' => 1,
+    ]);
+
+    expect((new Dashboard)->getTrialingSubscriptions())->toHaveCount(0);
+});
+
+it('counts trialing subscriptions in the dashboard KPIs', function () {
+    $trialTeam = ChatTeam::factory()->create();
+    $activeTeam = ChatTeam::factory()->create();
+
+    createSubscriptionRecord([
+        'team_id' => $trialTeam->id,
+        'type' => 'default',
+        'stripe_id' => 'sub_trial_kpi',
+        'stripe_status' => 'trialing',
+        'stripe_price' => 'price_pro',
+        'quantity' => 1,
+        'trial_ends_at' => now()->addDays(5),
+    ]);
+
+    createSubscriptionRecord([
+        'team_id' => $activeTeam->id,
+        'type' => 'default',
+        'stripe_id' => 'sub_active_kpi',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_pro',
+        'quantity' => 1,
+    ]);
+
+    $kpis = (new Dashboard)->getKpis();
+
+    expect($kpis['trialing_count'])->toBe(1)
+        ->and($kpis['subscription_count'])->toBe(2);
+});

--- a/tests/Feature/StripeSyncServiceTest.php
+++ b/tests/Feature/StripeSyncServiceTest.php
@@ -86,6 +86,25 @@ it('heals an existing product whose frequency is NULL', function () {
         ->and($product->frequency)->toBe(ResetFrequency::MONTHLY);
 });
 
+it('syncs the product image URL from Stripe', function () {
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct([
+        'images' => ['https://files.stripe.com/product-image.png'],
+    ]);
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->image_url)->toBe('https://files.stripe.com/product-image.png');
+});
+
+it('sets the image URL to null when the Stripe product has no image', function () {
+    $service = new StripeSyncService($this->aiCadStripe);
+
+    $product = invokeSyncProduct($service, makeStripeProduct(['images' => []]));
+
+    expect($product->image_url)->toBeNull();
+});
+
 it('updates basic attributes from Stripe payload', function () {
     SubscriptionProduct::factory()->create([
         'stripe_id' => 'prod_update_attrs',

--- a/tests/Feature/SubscriptionProductTableTest.php
+++ b/tests/Feature/SubscriptionProductTableTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Stripe\Collection as StripeCollection;
+use Stripe\Product as StripeProduct;
+use Tolery\AiCad\Livewire\Admin\SubscriptionProductTable;
+use Tolery\AiCad\Models\SubscriptionProduct;
+use Tolery\AiCad\Services\AiCadStripe;
+
+it('returns a Stripe error message when the catalogue cannot be loaded', function () {
+    $mock = Mockery::mock(AiCadStripe::class);
+    $mock->shouldReceive('listProducts')->andThrow(new Exception('Stripe unavailable'));
+    app()->instance(AiCadStripe::class, $mock);
+
+    $catalog = (new SubscriptionProductTable)->catalog();
+
+    expect($catalog['error'])->toBe('Stripe unavailable')
+        ->and($catalog['products'])->toBe([]);
+});
+
+it('pairs Stripe products with their local sync state', function () {
+    SubscriptionProduct::factory()->create([
+        'stripe_id' => 'prod_synced',
+        'name' => 'Plan Pro',
+        'description' => 'Le plan Pro',
+        'active' => true,
+        'image_url' => null,
+    ]);
+
+    $mock = Mockery::mock(AiCadStripe::class);
+    $mock->shouldReceive('listProducts')->andReturn(
+        StripeCollection::constructFrom(['data' => [
+            StripeProduct::constructFrom([
+                'id' => 'prod_synced',
+                'name' => 'Plan Pro',
+                'description' => 'Le plan Pro',
+                'active' => true,
+                'images' => [],
+            ]),
+            StripeProduct::constructFrom([
+                'id' => 'prod_new',
+                'name' => 'Plan New',
+                'description' => null,
+                'active' => true,
+                'images' => ['https://files.stripe.com/new.png'],
+            ]),
+        ]])
+    );
+    $mock->shouldReceive('listPrices')->andReturn(StripeCollection::constructFrom(['data' => []]));
+    app()->instance(AiCadStripe::class, $mock);
+
+    $catalog = (new SubscriptionProductTable)->catalog();
+
+    expect($catalog['error'])->toBeNull()
+        ->and($catalog['products'])->toHaveCount(2);
+
+    $synced = collect($catalog['products'])->firstWhere('id', 'prod_synced');
+    $new = collect($catalog['products'])->firstWhere('id', 'prod_new');
+
+    expect($synced['synced'])->toBeTrue()
+        ->and($synced['out_of_sync'])->toBeFalse()
+        ->and($new['synced'])->toBeFalse()
+        ->and($new['image'])->toBe('https://files.stripe.com/new.png');
+});
+
+it('flags a locally synced product as out of sync when Stripe data changed', function () {
+    SubscriptionProduct::factory()->create([
+        'stripe_id' => 'prod_drift',
+        'name' => 'Ancien nom',
+        'description' => 'Ancienne description',
+        'active' => true,
+        'image_url' => null,
+    ]);
+
+    $mock = Mockery::mock(AiCadStripe::class);
+    $mock->shouldReceive('listProducts')->andReturn(
+        StripeCollection::constructFrom(['data' => [
+            StripeProduct::constructFrom([
+                'id' => 'prod_drift',
+                'name' => 'Nouveau nom',
+                'description' => 'Ancienne description',
+                'active' => true,
+                'images' => [],
+            ]),
+        ]])
+    );
+    $mock->shouldReceive('listPrices')->andReturn(StripeCollection::constructFrom(['data' => []]));
+    app()->instance(AiCadStripe::class, $mock);
+
+    $catalog = (new SubscriptionProductTable)->catalog();
+
+    expect($catalog['products'][0]['synced'])->toBeTrue()
+        ->and($catalog['products'][0]['out_of_sync'])->toBeTrue();
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive Stripe product catalog management to the admin dashboard and introduces trial subscription tracking. It includes a new Livewire component for viewing and syncing Stripe products, enhanced dashboard KPIs with trial metrics, and a new admin page for product management.

## Key Changes

- **New SubscriptionProductTable Livewire Component**: Displays live Stripe catalog paired with local sync state, showing product details (name, description, image, pricing), sync status, and last sync timestamp. Includes a sync action that updates local products from Stripe.

- **Trial Subscription Tracking**: Added `getTrialingSubscriptions()` method to Dashboard component that collects teams currently on free trials with their plan details and days remaining. Displays in a new dashboard table showing team name, product, trial dates, and countdown.

- **Enhanced Dashboard KPIs**: Added `trialing_count` KPI to track active trial subscriptions separately from total subscriptions. Updated dashboard view with new amber-colored card for trial metrics.

- **Product Image Support**: Added `image_url` column to `subscription_products` table via migration. Updated `StripeSyncService` to sync product images from Stripe and store the first image URL locally.

- **New Admin Routes & Controller**: Added `SubscriptionProductController` with index action and new admin route `ai-cad.admin.products.index` for accessing the products page.

- **Product Management View**: Created `admin/products/index.blade.php` that renders the SubscriptionProductTable Livewire component with proper layout.

- **Comprehensive Tests**: Added test suites for trial subscription tracking (`DashboardTrialSubscriptionsTest.php`) and product table functionality (`SubscriptionProductTableTest.php`), including tests for sync state detection and out-of-sync flagging.

- **Configuration Updates**: Registered new Livewire component in service provider and added products link to admin navigation menu.

## Implementation Details

- Trial subscriptions are identified by `stripe_status = 'trialing'` and ordered by trial end date
- Products are flagged as "out of sync" when Stripe data (name, description, image, active status) differs from local records
- Sync operation handles errors gracefully with detailed feedback messages
- Product catalog gracefully handles Stripe API errors and missing price data
- Price formatting uses Laravel's `Number::currency()` helper with French locale
- Trial days calculation uses `diffInDays()` with proper date boundary handling

https://claude.ai/code/session_01YaYSwgTxuwbptYVZBurxcd