### PR TITLE
fix: avoid cashier invoice relation collision

### DIFF
--- a/src/Models/ChatTeam.php
+++ b/src/Models/ChatTeam.php
@@ -50,7 +50,7 @@ class ChatTeam extends Model
     /**
      * @return HasMany<Invoice, $this>
      */
-    public function invoices(): HasMany
+    public function aiCadInvoices(): HasMany
     {
         return $this->hasMany(Invoice::class, 'team_id');
     }

--- a/tests/Feature/InvoiceSyncTest.php
+++ b/tests/Feature/InvoiceSyncTest.php
@@ -8,6 +8,11 @@ use Tolery\AiCad\Models\Invoice;
 use Tolery\AiCad\Services\AiCadStripe;
 use Tolery\AiCad\Services\InvoiceSyncService;
 
+class CashierCompatibleChatTeam extends ChatTeam
+{
+    use Laravel\Cashier\Billable;
+}
+
 beforeEach(function () {
     config(['ai-cad.chat_team_model' => ChatTeam::class]);
 });
@@ -50,7 +55,14 @@ it('mirrors a subscription invoice into the local table', function () {
         ->and($invoice->total)->toBe(6000)
         ->and($invoice->number)->toBe('TOLERY-0001');
 
-    expect($team->invoices()->count())->toBe(1);
+    expect($team->aiCadInvoices()->count())->toBe(1);
+});
+
+it('keeps the Cashier invoices API available for application team models', function () {
+    $method = new ReflectionMethod(CashierCompatibleChatTeam::class, 'invoices');
+
+    expect($method->getNumberOfParameters())->toBe(2)
+        ->and($method->getReturnType()?->getName())->toBe(Illuminate\Support\Collection::class);
 });
 
 it('is idempotent when the same invoice is synced twice', function () {

--- a/tests/Feature/InvoiceSyncTest.php
+++ b/tests/Feature/InvoiceSyncTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Collection;
+use Laravel\Cashier\Billable;
 use Stripe\Event as StripeEvent;
 use Tolery\AiCad\Models\Chat;
 use Tolery\AiCad\Models\ChatTeam;
@@ -10,7 +12,7 @@ use Tolery\AiCad\Services\InvoiceSyncService;
 
 class CashierCompatibleChatTeam extends ChatTeam
 {
-    use Laravel\Cashier\Billable;
+    use Billable;
 }
 
 beforeEach(function () {
@@ -62,7 +64,7 @@ it('keeps the Cashier invoices API available for application team models', funct
     $method = new ReflectionMethod(CashierCompatibleChatTeam::class, 'invoices');
 
     expect($method->getNumberOfParameters())->toBe(2)
-        ->and($method->getReturnType()?->getName())->toBe(Illuminate\Support\Collection::class);
+        ->and($method->getReturnType()?->getName())->toBe(Collection::class);
 });
 
 it('is idempotent when the same invoice is synced twice', function () {


### PR DESCRIPTION
## Summary
- rename the local AI-CAD invoice relation to avoid overriding Cashier's invoices() API
- add a regression test for application team models that also use Billable

## Tests
- vendor/bin/pest tests/Feature/InvoiceSyncTest.php
- vendor/bin/phpstan analyse --memory-limit=2G
- vendor/bin/pint
- vendor/bin/pest