### PR TITLE
fix: rename ChatTeam::invoices() to localInvoices() to avoid Cashier collision

### DIFF
--- a/src/Models/ChatTeam.php
+++ b/src/Models/ChatTeam.php
@@ -48,9 +48,16 @@ class ChatTeam extends Model
     }
 
     /**
+     * Mirror local des factures Stripe (table `invoices`).
+     *
+     * Nommée `localInvoices` et non `invoices` pour ne pas entrer en conflit avec
+     * `Billable::invoices(): Collection` de Cashier : une app hôte qui étend ce
+     * modèle tout en utilisant le trait Billable provoquerait sinon une erreur
+     * fatale d'incompatibilité de signature.
+     *
      * @return HasMany<Invoice, $this>
      */
-    public function invoices(): HasMany
+    public function localInvoices(): HasMany
     {
         return $this->hasMany(Invoice::class, 'team_id');
     }

--- a/tests/Feature/InvoiceSyncTest.php
+++ b/tests/Feature/InvoiceSyncTest.php
@@ -50,7 +50,7 @@ it('mirrors a subscription invoice into the local table', function () {
         ->and($invoice->total)->toBe(6000)
         ->and($invoice->number)->toBe('TOLERY-0001');
 
-    expect($team->invoices()->count())->toBe(1);
+    expect($team->localInvoices()->count())->toBe(1);
 });
 
 it('is idempotent when the same invoice is synced twice', function () {


### PR DESCRIPTION
## Problème

`ChatTeam::invoices(): HasMany` (ajoutée pour le miroir local des factures Stripe) entre en conflit avec `Billable::invoices(): Collection` de Laravel Cashier.

Une app hôte dont le modèle Team `extends ChatTeam` **et** `use Billable` (cas de mn-tolery) provoque une erreur fatale :

> Declaration of `App\Models\Team::invoices(...): Collection` must be compatible with `Tolery\AiCad\Models\ChatTeam::invoices(): HasMany`

`ChatTeam` seul ne plante pas (sa méthode masque le trait), mais toute app qui l'étend casse — `App\Models\Team` est utilisé partout, donc l'app entière tombe.

## Correctif

Renomme la relation `invoices()` → `localInvoices()`. Aucun autre code du package ne référence cette relation (seul le test la mentionnait, mis à jour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)