### PR TITLE
chore: align main with released v1.15.7 (aiCadInvoices)

### DIFF
--- a/src/Models/ChatTeam.php
+++ b/src/Models/ChatTeam.php
@@ -48,16 +48,9 @@ class ChatTeam extends Model
     }
 
     /**
-     * Mirror local des factures Stripe (table `invoices`).
-     *
-     * Nommée `localInvoices` et non `invoices` pour ne pas entrer en conflit avec
-     * `Billable::invoices(): Collection` de Cashier : une app hôte qui étend ce
-     * modèle tout en utilisant le trait Billable provoquerait sinon une erreur
-     * fatale d'incompatibilité de signature.
-     *
      * @return HasMany<Invoice, $this>
      */
-    public function localInvoices(): HasMany
+    public function aiCadInvoices(): HasMany
     {
         return $this->hasMany(Invoice::class, 'team_id');
     }

--- a/tests/Feature/InvoiceSyncTest.php
+++ b/tests/Feature/InvoiceSyncTest.php
@@ -8,6 +8,11 @@ use Tolery\AiCad\Models\Invoice;
 use Tolery\AiCad\Services\AiCadStripe;
 use Tolery\AiCad\Services\InvoiceSyncService;
 
+class CashierCompatibleChatTeam extends ChatTeam
+{
+    use Laravel\Cashier\Billable;
+}
+
 beforeEach(function () {
     config(['ai-cad.chat_team_model' => ChatTeam::class]);
 });
@@ -50,7 +55,14 @@ it('mirrors a subscription invoice into the local table', function () {
         ->and($invoice->total)->toBe(6000)
         ->and($invoice->number)->toBe('TOLERY-0001');
 
-    expect($team->localInvoices()->count())->toBe(1);
+    expect($team->aiCadInvoices()->count())->toBe(1);
+});
+
+it('keeps the Cashier invoices API available for application team models', function () {
+    $method = new ReflectionMethod(CashierCompatibleChatTeam::class, 'invoices');
+
+    expect($method->getNumberOfParameters())->toBe(2)
+        ->and($method->getReturnType()?->getName())->toBe(Illuminate\Support\Collection::class);
 });
 
 it('is idempotent when the same invoice is synced twice', function () {

--- a/tests/Feature/InvoiceSyncTest.php
+++ b/tests/Feature/InvoiceSyncTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Collection;
+use Laravel\Cashier\Billable;
 use Stripe\Event as StripeEvent;
 use Tolery\AiCad\Models\Chat;
 use Tolery\AiCad\Models\ChatTeam;
@@ -10,7 +12,7 @@ use Tolery\AiCad\Services\InvoiceSyncService;
 
 class CashierCompatibleChatTeam extends ChatTeam
 {
-    use Laravel\Cashier\Billable;
+    use Billable;
 }
 
 beforeEach(function () {
@@ -62,7 +64,7 @@ it('keeps the Cashier invoices API available for application team models', funct
     $method = new ReflectionMethod(CashierCompatibleChatTeam::class, 'invoices');
 
     expect($method->getNumberOfParameters())->toBe(2)
-        ->and($method->getReturnType()?->getName())->toBe(Illuminate\Support\Collection::class);
+        ->and($method->getReturnType()?->getName())->toBe(Collection::class);
 });
 
 it('is idempotent when the same invoice is synced twice', function () {


### PR DESCRIPTION
## Contexte

Le conflit de signature `ChatTeam::invoices()` / Cashier `Billable::invoices()` a été corrigé **deux fois en parallèle** :

- **PR #166** — renomme la relation en `localInvoices()` → mergée dans `main`
- **Hotfix v1.15.7** (`d62220f`) — renomme la relation en `aiCadInvoices()` → taggé et **release publiée**, mais depuis un commit divergent, non mergé dans `main`

Résultat : `main` ≠ `v1.15.7`. Une prochaine release coupée depuis `main` re-renommerait `localInvoices()` → changement cassant vs la v1.15.7 déjà publiée.

## Changement

Aligne `src/Models/ChatTeam.php` et `tests/Feature/InvoiceSyncTest.php` sur le contenu de `v1.15.7`. La relation s'appelle `aiCadInvoices()` partout (nom canonique, déjà publié). Reprend aussi la couverture de non-régression Cashier ajoutée dans v1.15.7.

Après merge, `main` est identique en contenu à `v1.15.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)