### PR TITLE
fix: add horizontal gap in purchase modal price rows

### DIFF
--- a/resources/views/livewire/partials/purchase-modal.blade.php
+++ b/resources/views/livewire/partials/purchase-modal.blade.php
@@ -73,17 +73,17 @@
                                     $ttc = $ht + $tva;
                                 @endphp
                                 <div class="mb-4 space-y-1">
-                                    <div class="flex justify-between text-sm text-zinc-700">
+                                    <div class="flex justify-between gap-x-4 text-sm text-zinc-700">
                                         <span>Montant fichier CAO</span>
-                                        <span>{{ number_format($ht / 100, 2, ',', ' ') }} € HT</span>
+                                        <span class="shrink-0 whitespace-nowrap">{{ number_format($ht / 100, 2, ',', ' ') }} € HT</span>
                                     </div>
-                                    <div class="flex justify-between text-sm text-zinc-500">
+                                    <div class="flex justify-between gap-x-4 text-sm text-zinc-500">
                                         <span>TVA 20%</span>
-                                        <span>{{ number_format($tva / 100, 2, ',', ' ') }} €</span>
+                                        <span class="shrink-0 whitespace-nowrap">{{ number_format($tva / 100, 2, ',', ' ') }} €</span>
                                     </div>
-                                    <div class="flex justify-between text-base font-bold text-violettes pt-1 border-t border-zinc-200">
+                                    <div class="flex justify-between gap-x-4 text-base font-bold text-violettes pt-1 border-t border-zinc-200">
                                         <span>Total TTC</span>
-                                        <span>{{ number_format($ttc / 100, 2, ',', ' ') }} €</span>
+                                        <span class="shrink-0 whitespace-nowrap">{{ number_format($ttc / 100, 2, ',', ' ') }} €</span>
                                     </div>
                                 </div>
                             @endif


### PR DESCRIPTION
## Problème

Dans la modal « Télécharger ce fichier CAO », la ligne « Montant fichier CAO » et son montant « 49,00 € HT » étaient collés.

Les 3 lignes du récap utilisent `flex justify-between`, qui répartit l'espace **libre** entre les 2 spans. Le contenu de la 1re ligne remplit toute la largeur → espace libre nul → label et montant se touchent. Les lignes TVA / Total TTC, plus courtes, ne montraient pas le souci.

## Correctif

- `gap-x-4` sur les 3 lignes → écart minimum garanti
- `shrink-0 whitespace-nowrap` sur les montants → le prix ne se colle ni ne se coupe jamais

Classes utilitaires uniquement, compatible Tailwind v4. Validé visuellement en dev-mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)