### PR TITLE
feat: pre-fill the Stripe customer with the team billing address

### DIFF
--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -1128,9 +1128,28 @@ class Chatbot extends Component
         }
 
         try {
-            // Issuing a Stripe invoice requires a customer: attach the team if needed.
+            // Issuing a Stripe invoice requires a customer. We (re)sync the team's
+            // billing address onto the Stripe customer so the issued invoice carries
+            // the team's coordinates automatically. `main_address` / `getStripeArray()`
+            // belong to the host app's Team model, so they are read defensively.
+            $addressData = [];
+            $customerName = $team->name;
+            // @phpstan-ignore-next-line — `main_address` relation of the host app's Team model
+            $billingAddress = method_exists($team, 'main_address') ? $team->main_address : null;
+
+            if (is_object($billingAddress) && method_exists($billingAddress, 'getStripeArray')) {
+                $addressData = $billingAddress->getStripeArray();
+                $customerName = $billingAddress->society_name ?? $team->name;
+            }
+
+            $customer = $aiCadStripe->createOrUpdateCustomer(
+                email: $user->email,
+                name: $customerName,
+                existingCustomerId: $team->tolerycad_stripe_id,
+                address: $addressData,
+            );
+
             if (! $team->tolerycad_stripe_id) {
-                $customer = $aiCadStripe->createOrUpdateCustomer($user->email, $team->name);
                 $team->tolerycad_stripe_id = $customer->id;
                 $team->save();
             }

--- a/src/Services/AiCadStripe.php
+++ b/src/Services/AiCadStripe.php
@@ -229,13 +229,19 @@ class AiCadStripe
 
     /**
      * Create or update a Stripe customer for the team.
+     *
+     * @param  array<string, mixed>  $address  Optional billing address (Stripe `address` shape).
      */
-    public function createOrUpdateCustomer(string $email, string $name, ?string $existingCustomerId = null): Customer
+    public function createOrUpdateCustomer(string $email, string $name, ?string $existingCustomerId = null, array $address = []): Customer
     {
         $customerData = [
             'email' => $email,
             'name' => $name,
         ];
+
+        if ($address !== []) {
+            $customerData['address'] = $address;
+        }
 
         if ($existingCustomerId) {
             return $this->client()->customers->update($existingCustomerId, $customerData);


### PR DESCRIPTION
## Contexte

L'achat one-shot d'un fichier crée le Customer Stripe avec seulement l'email et le nom. L'acheteur doit ensuite **saisir son adresse** sur la page Stripe Checkout. Le flux abonnement, lui, pré-remplit déjà le Customer depuis l'adresse de la team.

Cette PR aligne le one-shot : l'adresse de facturation enregistrée de la team est synchronisée sur le Customer Stripe **avant** le checkout, pour que la facture émise par Stripe porte automatiquement les coordonnées de la team.

## Changements

- `AiCadStripe::createOrUpdateCustomer()` accepte une adresse optionnelle (paramètre `$address`, rétro-compatible).
- `Chatbot::purchaseFile()` lit `main_address` du modèle Team de l'app hôte **de façon défensive** (`method_exists` + `getStripeArray()`), et (re)synchronise l'adresse sur le Customer — qu'il soit créé ou réutilisé.

Le package ne connaît pas le modèle Team de l'app hôte ; les accès `main_address` / `getStripeArray()` sont donc gardés et annotés `@phpstan-ignore` (point de couplage hôte assumé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)