### PR TITLE
fix: refresh chatbot UI when CAD generation completes

### DIFF
--- a/resources/views/livewire/chatbot.blade.php
+++ b/resources/views/livewire/chatbot.blade.php
@@ -300,8 +300,12 @@
                         aicadLog('[AICAD] ✅ CadGenerationCompleted', e);
                         this.markStep('complete', 'Completed', 'Terminé', 100);
                         this.unsubscribe();
-                        // Refresh the Livewire component so the new message + viewer show up.
-                        $wire.$refresh();
+                        // Trigger the server-side listener so the new message text is
+                        // loaded from DB AND `jsonEdgesLoaded` is redispatched to the
+                        // viewer. `$wire.$refresh()` alone only re-renders the
+                        // component — it does NOT re-execute mount(), so the typing
+                        // indicator stays and the 3D viewer keeps its placeholder.
+                        $wire.dispatch('cad-generation-completed', { messageId: e.message_id });
                         setTimeout(() => this.close(), 800);
                         window.dispatchEvent(new CustomEvent('cad-generation-ended'));
                     })

--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -185,6 +185,43 @@ class Chatbot extends Component
         }
     }
 
+    /**
+     * Server-side counterpart to the `CadGenerationCompleted` broadcast event.
+     *
+     * Triggered from the Alpine `cadStreamModal` when the modal receives the
+     * Reverb event. A bare `$wire.$refresh()` re-renders the component but does
+     * NOT re-execute `mount()` — so neither the messages array nor the
+     * `jsonEdgesLoaded` dispatch were refreshed, leaving the typing indicator
+     * up and the 3D viewer on its placeholder.
+     *
+     * This handler reloads the messages from DB and re-fires every dispatch
+     * `mount()` normally does for the freshly generated message, so the UI
+     * lands in the same state as after a full page reload.
+     */
+    #[On('cad-generation-completed')]
+    public function onCadGenerationCompleted(int $messageId): void
+    {
+        // Reload the chat history so the assistant placeholder ('[TYPING_INDICATOR]')
+        // is replaced by the real generated message text.
+        $this->messages = $this->mapDbMessagesToArray();
+
+        $message = ChatMessage::find($messageId);
+
+        if (! $message || ! $message->ai_cad_path) {
+            return;
+        }
+
+        $jsonUrl = $message->getJSONEdgeUrl();
+        if ($jsonUrl) {
+            // Re-feed the Three.js viewer with the freshly generated piece.
+            $this->dispatch('jsonEdgesLoaded', jsonPath: $jsonUrl);
+        }
+
+        $this->updateExportUrls($message);
+        $this->dispatchExportLinks($message);
+        $this->updateDownloadStatus();
+    }
+
     #[On('face-selection-state-changed')]
     public function updateComposerPlaceholder(bool $hasSelection): void
     {


### PR DESCRIPTION
## Context

In Phase 2 of the async CAD generation refactor (ticket #152), the generation runs on the `tolerycad-long` queue worker and pushes progress / completion events to the browser through Reverb private channel `chat.{id}`.

The Alpine `cadStreamModal` correctly subscribes to that channel and updates the 5-step progress indicator. But on `CadGenerationCompleted`, it called a bare `$wire.$refresh()` to surface the new assistant message and reload the 3D viewer.

## The bug

`$wire.$refresh()` in Livewire 4 only re-runs `render()`. It does **not** re-execute `mount()`. Consequence:

- `$this->messages` stays bound to the initial mount() snapshot → the assistant slot keeps its `[TYPING_INDICATOR]` placeholder forever.
- `jsonEdgesLoaded` is **only dispatched from `mount()`** → the Three.js viewer keeps its placeholder, never receives the new piece.

So after a successful generation the user sees the progress modal close, but the chat still shows the typing dots and the viewer still shows "Votre pièce apparaîtra ici…".

## Fix

Replace the bare `$refresh` with a Livewire dispatch to a new server-side listener:

```js
$wire.dispatch('cad-generation-completed', { messageId: e.message_id });
```

The new `#[On('cad-generation-completed')] onCadGenerationCompleted(int $messageId)` method:

1. Reloads `$this->messages` from DB → typing indicator replaced by the real text;
2. Re-dispatches `jsonEdgesLoaded` with the new piece's JSON edge URL → viewer recharges;
3. Re-fires `updateExportUrls`, `dispatchExportLinks`, `updateDownloadStatus` → export links + download status panel update.

End state matches what a hard page reload would do — but without the reload.

## Test plan

1. New chat → ask for any part → `ok` → modal opens, progresses through the 5 steps, closes.
2. **Expected:** assistant message replaces typing dots with TolerCAD response **AND** the 3D viewer recharges with the generated piece.
3. **Before this fix:** modal closes but both stay on placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)