### PR TITLE
fix: skip CAD notification emails when user is currently on the app

### DIFF
--- a/database/migrations/2020_05_21_100001_create_users_table.php
+++ b/database/migrations/2020_05_21_100001_create_users_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
             Schema::create('users', function (Blueprint $table) {
                 $table->id();
                 $table->foreignId('team_id')->index()->nullable()->constrained()->cascadeOnDelete();
+                $table->timestamp('last_seen_at')->nullable();
                 $table->timestamps();
             });
         }
@@ -30,6 +31,17 @@ return new class extends Migration
         if (! Schema::hasColumn('users', 'team_id')) {
             Schema::table('users', function (Blueprint $table) {
                 $table->foreignId('team_id')->index()->nullable()->constrained()->cascadeOnDelete();
+            });
+        }
+
+        // `last_seen_at` is owned by the host app's `users` table (mn-tolery
+        // updates it via TrackUserActivity middleware). The package only reads
+        // it through `UserPresence` to decide whether to skip redundant
+        // email notifications. We declare it here so the package's test suite
+        // can simulate online/offline users.
+        if (! Schema::hasColumn('users', 'last_seen_at')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->timestamp('last_seen_at')->nullable();
             });
         }
     }

--- a/src/Jobs/SendCompletionEmailIfUnreadJob.php
+++ b/src/Jobs/SendCompletionEmailIfUnreadJob.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use Tolery\AiCad\Models\ChatMessage;
 use Tolery\AiCad\Notifications\CadGenerationCompletedNotification;
+use Tolery\AiCad\Support\UserPresence;
 
 /**
  * Dispatched (with a delay) immediately after the database completion notification
@@ -38,6 +39,20 @@ class SendCompletionEmailIfUnreadJob implements ShouldQueue
         $user = $message->user ?? $message->chat?->user;
 
         if (! $user) {
+            return;
+        }
+
+        // Issue #2199 — don't email a user who is actively on the chatbot UI:
+        // the cloche notification is already visible, an email on top of it
+        // just fills their inbox. The host app refreshes `last_seen_at` on
+        // every authenticated request, so a "recent" timestamp is a strong
+        // signal the user is still around.
+        if (UserPresence::isOnline($user)) {
+            Log::info('[AICAD] Completion email skipped — user currently online', [
+                'message_id' => $message->id,
+                'user_id' => $user->getKey(),
+            ]);
+
             return;
         }
 

--- a/src/Notifications/CadGenerationFailedNotification.php
+++ b/src/Notifications/CadGenerationFailedNotification.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Tolery\AiCad\Models\ChatMessage;
+use Tolery\AiCad\Support\UserPresence;
 
 class CadGenerationFailedNotification extends Notification implements ShouldQueue
 {
@@ -18,13 +19,19 @@ class CadGenerationFailedNotification extends Notification implements ShouldQueu
     ) {}
 
     /**
-     * Failure notifications are always sent by both database and email — the user
-     * needs to know without having to come back to the app.
+     * Failure notifications go through both the database (cloche) and email
+     * channels so a user who closed the tab still hears about it. When the
+     * user is actively on the chatbot UI (issue #2199), the cloche alone is
+     * enough — we drop the email to avoid inbox spam.
      *
      * @return array<int, string>
      */
     public function via(mixed $notifiable): array
     {
+        if (UserPresence::isOnline($notifiable)) {
+            return ['database'];
+        }
+
         return ['database', 'mail'];
     }
 

--- a/src/Support/UserPresence.php
+++ b/src/Support/UserPresence.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tolery\AiCad\Support;
+
+use Carbon\Carbon;
+use DateTimeInterface;
+
+/**
+ * Online-presence detection for ToleryCAD users.
+ *
+ * Backed by the host application's `users.last_seen_at` column, which is kept
+ * fresh by a middleware on every authenticated request (see mn-tolery's
+ * `TrackUserActivity`). Used to suppress redundant email notifications when
+ * the user is already watching the chatbot UI — the database (cloche)
+ * notification is enough in that case.
+ */
+class UserPresence
+{
+    /**
+     * Whether the given user can be considered "currently on the app".
+     *
+     * Returns false defensively when:
+     *  - the user is null,
+     *  - the host User model doesn't carry a `last_seen_at` attribute,
+     *  - the column has never been populated (NULL).
+     *
+     * The freshness window is configurable via
+     * `ai-cad.notifications.online_threshold_seconds` (default 30 seconds),
+     * intentionally generous to cover the host middleware throttle.
+     */
+    public static function isOnline(mixed $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        $lastSeenAt = $user->last_seen_at ?? null;
+
+        if ($lastSeenAt === null) {
+            return false;
+        }
+
+        if (! $lastSeenAt instanceof DateTimeInterface) {
+            try {
+                $lastSeenAt = Carbon::parse((string) $lastSeenAt);
+            } catch (\Throwable) {
+                return false;
+            }
+        }
+
+        $thresholdSeconds = (int) config('ai-cad.notifications.online_threshold_seconds', 30);
+
+        return Carbon::instance($lastSeenAt)->diffInSeconds(Carbon::now(), true) <= $thresholdSeconds;
+    }
+}

--- a/tests/Feature/Job/SendCompletionEmailIfUnreadJobTest.php
+++ b/tests/Feature/Job/SendCompletionEmailIfUnreadJobTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Schema;
+use Tolery\AiCad\Jobs\SendCompletionEmailIfUnreadJob;
+use Tolery\AiCad\Models\Chat;
+use Tolery\AiCad\Models\ChatMessage;
+use Tolery\AiCad\Models\ChatTeam;
+use Tolery\AiCad\Models\ChatUser;
+use Tolery\AiCad\Notifications\CadGenerationCompletedNotification;
+
+beforeEach(function () {
+    Notification::fake();
+
+    config()->set('ai-cad.notifications.online_threshold_seconds', 30);
+    config()->set('ai-cad.chat_user_model', ChatUser::class);
+
+    // Mimic the host app's Laravel `notifications` table (created by
+    // `php artisan notifications:table` in real installs).
+    if (! Schema::hasTable('notifications')) {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+});
+
+function makeChatMessageForCompletion(?\Carbon\Carbon $lastSeenAt): ChatMessage
+{
+    $team = ChatTeam::factory()->create();
+
+    $user = ChatUser::query()->create([
+        'team_id' => $team->id,
+        'last_seen_at' => $lastSeenAt,
+    ]);
+
+    $chat = Chat::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $team->id,
+    ]);
+
+    return ChatMessage::query()->create([
+        'chat_id' => $chat->id,
+        'user_id' => $user->id,
+        'role' => 'assistant',
+        'message' => 'done',
+    ]);
+}
+
+function insertDatabaseNotification(ChatMessage $message, ?\Carbon\Carbon $readAt): void
+{
+    \Illuminate\Support\Facades\DB::table('notifications')->insert([
+        'id' => (string) \Illuminate\Support\Str::uuid(),
+        'type' => CadGenerationCompletedNotification::class,
+        'notifiable_type' => ChatUser::class,
+        'notifiable_id' => $message->user->getKey(),
+        'data' => json_encode(['message_id' => $message->id]),
+        'read_at' => $readAt,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+test('sends email when notification unread and user offline', function () {
+    $message = makeChatMessageForCompletion(lastSeenAt: now()->subMinutes(10));
+
+    // Simulate the unread database notification recorded just before the
+    // delayed job fires.
+    insertDatabaseNotification($message, readAt: null);
+
+    (new SendCompletionEmailIfUnreadJob($message->id))->handle();
+
+    Notification::assertSentTo(
+        $message->user,
+        CadGenerationCompletedNotification::class,
+    );
+});
+
+test('skips email when user is currently online (issue #2199)', function () {
+    $message = makeChatMessageForCompletion(lastSeenAt: now()->subSeconds(5));
+
+    insertDatabaseNotification($message, readAt: null);
+
+    (new SendCompletionEmailIfUnreadJob($message->id))->handle();
+
+    Notification::assertNothingSent();
+});
+
+test('skips email when notification already read', function () {
+    $message = makeChatMessageForCompletion(lastSeenAt: now()->subMinutes(10));
+
+    insertDatabaseNotification($message, readAt: now());
+
+    (new SendCompletionEmailIfUnreadJob($message->id))->handle();
+
+    Notification::assertNothingSent();
+});

--- a/tests/Feature/Job/SendCompletionEmailIfUnreadJobTest.php
+++ b/tests/Feature/Job/SendCompletionEmailIfUnreadJobTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use Carbon\Carbon;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Tolery\AiCad\Jobs\SendCompletionEmailIfUnreadJob;
 use Tolery\AiCad\Models\Chat;
 use Tolery\AiCad\Models\ChatMessage;
@@ -30,7 +33,7 @@ beforeEach(function () {
     }
 });
 
-function makeChatMessageForCompletion(?\Carbon\Carbon $lastSeenAt): ChatMessage
+function makeChatMessageForCompletion(?Carbon $lastSeenAt): ChatMessage
 {
     $team = ChatTeam::factory()->create();
 
@@ -52,10 +55,10 @@ function makeChatMessageForCompletion(?\Carbon\Carbon $lastSeenAt): ChatMessage
     ]);
 }
 
-function insertDatabaseNotification(ChatMessage $message, ?\Carbon\Carbon $readAt): void
+function insertDatabaseNotification(ChatMessage $message, ?Carbon $readAt): void
 {
-    \Illuminate\Support\Facades\DB::table('notifications')->insert([
-        'id' => (string) \Illuminate\Support\Str::uuid(),
+    DB::table('notifications')->insert([
+        'id' => (string) Str::uuid(),
         'type' => CadGenerationCompletedNotification::class,
         'notifiable_type' => ChatUser::class,
         'notifiable_id' => $message->user->getKey(),

--- a/tests/Feature/Notifications/CadGenerationFailedNotificationTest.php
+++ b/tests/Feature/Notifications/CadGenerationFailedNotificationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Tolery\AiCad\Models\Chat;
+use Tolery\AiCad\Models\ChatMessage;
+use Tolery\AiCad\Models\ChatTeam;
+use Tolery\AiCad\Models\ChatUser;
+use Tolery\AiCad\Notifications\CadGenerationFailedNotification;
+
+beforeEach(function () {
+    config()->set('ai-cad.notifications.online_threshold_seconds', 30);
+    config()->set('ai-cad.chat_user_model', ChatUser::class);
+});
+
+function makeChatMessageForFailure(?\Carbon\Carbon $lastSeenAt): ChatMessage
+{
+    $team = ChatTeam::factory()->create();
+
+    $user = ChatUser::query()->create([
+        'team_id' => $team->id,
+        'last_seen_at' => $lastSeenAt,
+    ]);
+
+    $chat = Chat::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $team->id,
+    ]);
+
+    return ChatMessage::query()->create([
+        'chat_id' => $chat->id,
+        'user_id' => $user->id,
+        'role' => 'assistant',
+        'message' => 'failed',
+    ]);
+}
+
+test('failure notification ships database+mail for offline users', function () {
+    $message = makeChatMessageForFailure(lastSeenAt: now()->subMinutes(10));
+
+    $notification = new CadGenerationFailedNotification($message, 'boom');
+
+    expect($notification->via($message->user))->toBe(['database', 'mail']);
+});
+
+test('failure notification skips mail for users currently online (issue #2199)', function () {
+    $message = makeChatMessageForFailure(lastSeenAt: now()->subSeconds(5));
+
+    $notification = new CadGenerationFailedNotification($message, 'boom');
+
+    expect($notification->via($message->user))->toBe(['database']);
+});
+
+test('failure notification ships database+mail when user has never been seen', function () {
+    $message = makeChatMessageForFailure(lastSeenAt: null);
+
+    $notification = new CadGenerationFailedNotification($message, 'boom');
+
+    expect($notification->via($message->user))->toBe(['database', 'mail']);
+});

--- a/tests/Feature/Notifications/CadGenerationFailedNotificationTest.php
+++ b/tests/Feature/Notifications/CadGenerationFailedNotificationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Tolery\AiCad\Models\Chat;
 use Tolery\AiCad\Models\ChatMessage;
 use Tolery\AiCad\Models\ChatTeam;
@@ -11,7 +12,7 @@ beforeEach(function () {
     config()->set('ai-cad.chat_user_model', ChatUser::class);
 });
 
-function makeChatMessageForFailure(?\Carbon\Carbon $lastSeenAt): ChatMessage
+function makeChatMessageForFailure(?Carbon $lastSeenAt): ChatMessage
 {
     $team = ChatTeam::factory()->create();
 

--- a/tests/Feature/Support/UserPresenceTest.php
+++ b/tests/Feature/Support/UserPresenceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Tolery\AiCad\Models\ChatUser;
+use Tolery\AiCad\Support\UserPresence;
+
+test('user is offline when null', function () {
+    expect(UserPresence::isOnline(null))->toBeFalse();
+});
+
+test('user is offline when last_seen_at is null', function () {
+    $user = new ChatUser;
+    $user->last_seen_at = null;
+
+    expect(UserPresence::isOnline($user))->toBeFalse();
+});
+
+test('user is offline when last_seen_at is older than the threshold', function () {
+    config()->set('ai-cad.notifications.online_threshold_seconds', 30);
+
+    $user = new ChatUser;
+    $user->last_seen_at = now()->subSeconds(120);
+
+    expect(UserPresence::isOnline($user))->toBeFalse();
+});
+
+test('user is online when last_seen_at is within the threshold', function () {
+    config()->set('ai-cad.notifications.online_threshold_seconds', 30);
+
+    $user = new ChatUser;
+    $user->last_seen_at = now()->subSeconds(10);
+
+    expect(UserPresence::isOnline($user))->toBeTrue();
+});
+
+test('user is online just inside the threshold boundary', function () {
+    config()->set('ai-cad.notifications.online_threshold_seconds', 30);
+
+    $user = new ChatUser;
+    // Half a threshold worth of slack — Carbon::diffInSeconds returns a float
+    // so testing at the exact boundary is racy.
+    $user->last_seen_at = now()->subSeconds(29);
+
+    expect(UserPresence::isOnline($user))->toBeTrue();
+});
+
+test('threshold is configurable', function () {
+    config()->set('ai-cad.notifications.online_threshold_seconds', 5);
+
+    $user = new ChatUser;
+    $user->last_seen_at = now()->subSeconds(10);
+
+    expect(UserPresence::isOnline($user))->toBeFalse();
+
+    config()->set('ai-cad.notifications.online_threshold_seconds', 60);
+
+    expect(UserPresence::isOnline($user))->toBeTrue();
+});
+
+test('string last_seen_at is parsed gracefully', function () {
+    config()->set('ai-cad.notifications.online_threshold_seconds', 30);
+
+    $user = new ChatUser;
+    $user->last_seen_at = now()->subSeconds(10)->toDateTimeString();
+
+    expect(UserPresence::isOnline($user))->toBeTrue();
+});
+
+test('garbage last_seen_at returns false instead of throwing', function () {
+    $user = new ChatUser;
+    $user->last_seen_at = 'not-a-date';
+
+    expect(UserPresence::isOnline($user))->toBeFalse();
+});


### PR DESCRIPTION
Closes #2199 (mn-tolery).

## Problème

Le chatbot envoyait un email à chaque génération CAO, même quand l'utilisateur regardait déjà la conversation. Combiné aux notifications d'échec (toujours mailées), ça produisait trop de mail dans les boîtes utilisateurs.

## Solution

Helper `Tolery\AiCad\Support\UserPresence::isOnline($user)` qui lit `users.last_seen_at` (colonne tenue à jour par le middleware côté app hôte — `TrackUserActivity` dans mn-tolery). Si l'utilisateur a été actif dans la fenêtre configurée (`ai-cad.notifications.online_threshold_seconds`, défaut 30 s), on saute les canaux mail :

- `SendCompletionEmailIfUnreadJob` : pas d'email même si la cloche reste non-lue → on suppose qu'elle est visible à l'écran.
- `CadGenerationFailedNotification::via()` : `['database']` au lieu de `['database', 'mail']`.

La notification base (cloche) reste systématiquement envoyée — c'est elle qui assure le feedback in-app.

## Configuration

Nouveau bloc dans `config/ai-cad.php` :

```php
'notifications' => [
    'online_threshold_seconds' => env('AICAD_ONLINE_THRESHOLD_SECONDS', 30),
],
```

## Tests

- `tests/Feature/Support/UserPresenceTest.php` — null user, last_seen_at null, en-dehors / dans la fenêtre, seuil configurable, parsing string, garbage.
- `tests/Feature/Job/SendCompletionEmailIfUnreadJobTest.php` — email envoyé hors-ligne / sauté online / sauté si lu.
- `tests/Feature/Notifications/CadGenerationFailedNotificationTest.php` — `via()` retourne `[database, mail]` hors-ligne / `[database]` online / `[database, mail]` si jamais connecté.

74 tests passent (`./vendor/bin/pest`). Pint clean.

## À faire côté hôte (mn-tolery)

PR de bump à suivre : baisser `TrackUserActivity::THROTTLE_SECONDS` de 60 → 15 s pour que la fenêtre de détection soit plus fiable.