### PR TITLE
feat(admin): refonte dashboard + 2e sidebar ToleryCAD (#2180)

### DIFF
--- a/resources/views/admin/chats/index.blade.php
+++ b/resources/views/admin/chats/index.blade.php
@@ -1,7 +1,3 @@
-<x-layout.app>
-    <x-slot:title returnUrl="{{ route('ai-cad.admin.dashboard') }}">
-        ToleryCad - Conversations
-    </x-slot>
-
+<x-layout.admin.tolerycad title="ToleryCAD - Conversations">
     <livewire:ai-cad-admin-chat-table />
-</x-layout.app>
+</x-layout.admin.tolerycad>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,5 +1,3 @@
-<x-layout.app>
-    <x-slot:title>ToleryCad - Dashboard</x-slot>
-
+<x-layout.admin.tolerycad title="ToleryCAD - Tableau de bord">
     <livewire:ai-cad-admin-dashboard />
-</x-layout.app>
+</x-layout.admin.tolerycad>

--- a/resources/views/admin/downloads/index.blade.php
+++ b/resources/views/admin/downloads/index.blade.php
@@ -1,7 +1,3 @@
-<x-layout.app>
-    <x-slot:title returnUrl="{{ route('ai-cad.admin.dashboard') }}">
-        ToleryCad - Téléchargements
-    </x-slot>
-
+<x-layout.admin.tolerycad title="ToleryCAD - Téléchargements">
     <livewire:ai-cad-admin-chat-download-table />
-</x-layout.app>
+</x-layout.admin.tolerycad>

--- a/resources/views/admin/products/index.blade.php
+++ b/resources/views/admin/products/index.blade.php
@@ -1,7 +1,3 @@
-<x-layout.app>
-    <x-slot:title returnUrl="{{ route('ai-cad.admin.dashboard') }}">
-        ToleryCad - Produits Stripe
-    </x-slot>
-
+<x-layout.admin.tolerycad title="ToleryCAD - Produits Stripe">
     <livewire:ai-cad-admin-subscription-product-table />
-</x-layout.app>
+</x-layout.admin.tolerycad>

--- a/resources/views/admin/prompts/index.blade.php
+++ b/resources/views/admin/prompts/index.blade.php
@@ -1,8 +1,4 @@
-<x-layout.app>
-    <x-slot:title returnUrl="{{ route('ai-cad.admin.dashboard') }}">
-        ToleryCad - Prompts prédéfinis
-    </x-slot>
-
+<x-layout.admin.tolerycad title="ToleryCAD - Prompts prédéfinis">
     <div class="mb-4 flex justify-end">
         <flux:button href="{{ route('ai-cad.admin.prompts.create') }}" icon="plus">
             Nouveau prompt
@@ -10,4 +6,4 @@
     </div>
 
     <livewire:ai-cad-admin-predefined-prompt-table />
-</x-layout.app>
+</x-layout.admin.tolerycad>

--- a/resources/views/admin/purchases/index.blade.php
+++ b/resources/views/admin/purchases/index.blade.php
@@ -1,7 +1,3 @@
-<x-layout.app>
-    <x-slot:title returnUrl="{{ route('ai-cad.admin.dashboard') }}">
-        ToleryCad - Achats de fichiers
-    </x-slot>
-
+<x-layout.admin.tolerycad title="ToleryCAD - Achats de fichiers">
     <livewire:ai-cad-admin-file-purchase-table />
-</x-layout.app>
+</x-layout.admin.tolerycad>

--- a/resources/views/admin/step-messages/index.blade.php
+++ b/resources/views/admin/step-messages/index.blade.php
@@ -1,13 +1,9 @@
-<x-layout.app>
-    <x-slot:title returnUrl="{{ route('ai-cad.admin.dashboard') }}">
-        ToleryCad - Messages d'etape
-    </x-slot>
-
+<x-layout.admin.tolerycad title="ToleryCAD - Messages d'étape">
     <div class="mb-4 flex justify-end">
         <flux:button href="{{ route('ai-cad.admin.step-messages.create') }}" icon="plus">
-            Nouveau message d'etape
+            Nouveau message d'étape
         </flux:button>
     </div>
 
     <livewire:ai-cad-admin-step-message-table />
-</x-layout.app>
+</x-layout.admin.tolerycad>

--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -1,12 +1,22 @@
+@php
+    /**
+     * Render a period-over-period delta as a coloured Flux badge.
+     * $value is a percentage (float) or an absolute count (int); null hides the badge.
+     */
+    $deltaColor = fn ($value) => $value === null ? 'zinc' : ($value > 0 ? 'green' : ($value < 0 ? 'red' : 'zinc'));
+
+    $maxByProduct = collect($kpis['subscriptions_by_product'])->max() ?: 1;
+@endphp
+
 <div>
     {{-- Header with Period Selector --}}
-    <div class="mb-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+    <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
             <div class="flex items-center gap-3">
-                <flux:heading level="1" size="xl">Dashboard ToleryCAD</flux:heading>
+                <flux:heading level="1" size="xl">Tableau de bord</flux:heading>
                 <flux:badge color="zinc" size="sm">v{{ $version }}</flux:badge>
             </div>
-            <flux:text class="text-gray-500">Statistiques et revenus</flux:text>
+            <flux:text class="text-zinc-500">Revenus, abonnements et activité de la plateforme ToleryCAD.</flux:text>
         </div>
         <flux:date-picker
             wire:model.live="range"
@@ -21,70 +31,82 @@
         </flux:date-picker>
     </div>
 
-    {{-- Revenue Summary --}}
-    <flux:heading level="2" size="lg" class="mb-4">Revenus</flux:heading>
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-3 mb-8">
-        <flux:card class="bg-green-50 dark:bg-green-900/20">
-            <flux:heading level="3" size="sm">Total revenus ToleryCAD</flux:heading>
-            <div class="mt-2 text-3xl font-bold text-green-600 dark:text-green-400">{{ number_format($kpis['total_revenue'], 2, ',', ' ') }} €</div>
-            <flux:text class="text-sm text-gray-500 mt-1">Sur la période sélectionnée</flux:text>
-        </flux:card>
+    {{-- Revenue KPIs --}}
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+        @php
+            $revenueCards = [
+                ['label' => 'Revenus totaux', 'value' => $kpis['total_revenue'], 'delta' => $kpis['deltas']['total_revenue'], 'icon' => 'banknotes'],
+                ['label' => 'Revenus abonnements', 'value' => $kpis['subscription_revenue'], 'delta' => $kpis['deltas']['subscription_revenue'], 'icon' => 'arrow-path'],
+                ['label' => 'Revenus à la pièce', 'value' => $kpis['purchase_revenue'], 'delta' => $kpis['deltas']['purchase_revenue'], 'icon' => 'cube'],
+            ];
+        @endphp
 
-        <flux:card>
-            <flux:heading level="3" size="sm">Revenus abonnements</flux:heading>
-            <div class="mt-2 text-3xl font-bold text-purple-600 dark:text-purple-400">{{ number_format($kpis['subscription_revenue'], 2, ',', ' ') }} €</div>
-            <flux:text class="text-sm text-gray-500 mt-1">Nouveaux abonnements sur la période</flux:text>
-        </flux:card>
+        @foreach ($revenueCards as $card)
+            <flux:card class="flex flex-col gap-2">
+                <div class="flex items-center justify-between">
+                    <flux:text class="text-sm font-medium text-zinc-500">{{ $card['label'] }}</flux:text>
+                    <flux:icon :name="$card['icon']" class="size-4 text-zinc-400" />
+                </div>
+                <div class="text-2xl font-bold tabular-nums">{{ number_format($card['value'], 2, ',', ' ') }} €</div>
+                <div class="mt-auto">
+                    @if ($card['delta'] !== null)
+                        <flux:badge :color="$deltaColor($card['delta'])" size="sm">
+                            {{ $card['delta'] > 0 ? '+' : '' }}{{ number_format($card['delta'], 1, ',', ' ') }} %
+                        </flux:badge>
+                        <flux:text class="ml-1 text-xs text-zinc-500">vs période précédente</flux:text>
+                    @else
+                        <flux:text class="text-xs text-zinc-400">Sur la période sélectionnée</flux:text>
+                    @endif
+                </div>
+            </flux:card>
+        @endforeach
 
-        <flux:card>
-            <flux:heading level="3" size="sm">Revenus achats unitaires</flux:heading>
-            <div class="mt-2 text-3xl font-bold text-blue-600 dark:text-blue-400">{{ number_format($kpis['purchase_revenue'], 2, ',', ' ') }} €</div>
-            <flux:text class="text-sm text-gray-500 mt-1">{{ $kpis['purchase_count'] }} achat(s) de fichier</flux:text>
+        <flux:card class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+                <flux:text class="text-sm font-medium text-zinc-500">Abonnés</flux:text>
+                <flux:icon name="user-group" class="size-4 text-zinc-400" />
+            </div>
+            <div class="text-2xl font-bold tabular-nums">{{ $kpis['subscription_count'] }}</div>
+            <div class="mt-auto flex flex-wrap gap-1.5">
+                <flux:badge color="green" size="sm">{{ $kpis['paying_count'] }} payant{{ $kpis['paying_count'] > 1 ? 's' : '' }}</flux:badge>
+                <flux:badge color="amber" size="sm">{{ $kpis['trialing_count'] }} en essai</flux:badge>
+                @if ($kpis['at_risk_count'] > 0)
+                    <flux:badge color="red" size="sm">{{ $kpis['at_risk_count'] }} à risque</flux:badge>
+                @endif
+            </div>
         </flux:card>
     </div>
 
-    {{-- Subscriptions --}}
-    <flux:heading level="2" size="lg" class="mb-4">Abonnements actifs</flux:heading>
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4 mb-8">
-        <flux:card class="bg-purple-50 dark:bg-purple-900/20">
-            <flux:heading level="3" size="sm">Total abonnés</flux:heading>
-            <div class="mt-2 text-3xl font-bold text-purple-600 dark:text-purple-400">{{ $kpis['subscription_count'] }}</div>
-            <flux:text class="text-sm text-gray-500 mt-1">actifs et essais inclus</flux:text>
-        </flux:card>
-
-        <flux:card class="bg-amber-50 dark:bg-amber-900/20">
-            <flux:heading level="3" size="sm">Essais gratuits en cours</flux:heading>
-            <div class="mt-2 text-3xl font-bold text-amber-600 dark:text-amber-400">{{ $kpis['trialing_count'] }}</div>
-            <flux:text class="text-sm text-gray-500 mt-1">compte(s) en période d'essai</flux:text>
-        </flux:card>
-
+    {{-- Subscriptions breakdown by plan --}}
+    <flux:heading level="2" size="lg" class="mb-4">Abonnements actifs par plan</flux:heading>
+    <flux:card class="mb-8">
         @forelse ($kpis['subscriptions_by_product'] as $productName => $count)
-            <flux:card>
-                <flux:heading level="3" size="sm">{{ $productName }}</flux:heading>
-                <div class="mt-2 text-3xl font-bold">{{ $count }}</div>
-                <flux:text class="text-sm text-gray-500 mt-1">abonné(s)</flux:text>
-            </flux:card>
+            <div class="flex items-center gap-3 py-1.5">
+                <span class="w-40 shrink-0 text-sm text-zinc-600 dark:text-zinc-300 truncate">{{ $productName }}</span>
+                <div class="flex-1 h-2 rounded-full bg-zinc-100 dark:bg-zinc-700 overflow-hidden">
+                    <div class="h-full rounded-full bg-violet-600" style="width: {{ max(4, round(($count / $maxByProduct) * 100)) }}%;"></div>
+                </div>
+                <span class="w-10 text-right text-sm font-medium tabular-nums">{{ $count }}</span>
+            </div>
         @empty
-            <flux:card class="md:col-span-3">
-                <flux:text class="text-gray-500">Aucun abonnement actif</flux:text>
-            </flux:card>
+            <flux:text class="text-zinc-500">Aucun abonnement actif.</flux:text>
         @endforelse
-    </div>
+    </flux:card>
 
     {{-- Comptes en essai gratuit --}}
     <flux:heading level="2" size="lg" class="mb-4">Comptes en essai gratuit</flux:heading>
-    <div class="mb-8 overflow-hidden rounded-xl border border-gray-100 dark:border-gray-700">
+    <div class="mb-8 overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-700">
         @if ($trialingSubscriptions->isEmpty())
             <div class="p-6">
-                <flux:text class="text-gray-500">Aucun compte en essai gratuit actuellement.</flux:text>
+                <flux:text class="text-zinc-500">Aucun compte en essai gratuit actuellement.</flux:text>
             </div>
         @else
             <div class="overflow-x-auto">
                 <table class="w-full text-sm">
                     <thead>
-                        <tr class="border-b border-gray-100 text-left text-gray-500 dark:border-gray-700">
+                        <tr class="border-b border-zinc-200 text-left text-zinc-500 dark:border-zinc-700">
                             <th class="px-4 py-3 font-medium">Équipe</th>
-                            <th class="px-4 py-3 font-medium">Produit</th>
+                            <th class="px-4 py-3 font-medium">Plan</th>
                             <th class="px-4 py-3 font-medium">Début d'essai</th>
                             <th class="px-4 py-3 font-medium">Fin d'essai</th>
                             <th class="px-4 py-3 font-medium">Jours restants</th>
@@ -92,14 +114,14 @@
                     </thead>
                     <tbody>
                         @foreach ($trialingSubscriptions as $trial)
-                            <tr class="border-b border-gray-50 last:border-0 dark:border-gray-800">
+                            <tr class="border-b border-zinc-100 last:border-0 dark:border-zinc-800">
                                 <td class="px-4 py-3 font-medium">{{ $trial['team_name'] }}</td>
                                 <td class="px-4 py-3">{{ $trial['product_name'] }}</td>
-                                <td class="px-4 py-3 text-gray-500">{{ $trial['started_at']?->format('d/m/Y') ?? '-' }}</td>
-                                <td class="px-4 py-3 text-gray-500">{{ $trial['trial_ends_at']?->format('d/m/Y') ?? '-' }}</td>
+                                <td class="px-4 py-3 text-zinc-500">{{ $trial['started_at']?->format('d/m/Y') ?? '-' }}</td>
+                                <td class="px-4 py-3 text-zinc-500">{{ $trial['trial_ends_at']?->format('d/m/Y') ?? '-' }}</td>
                                 <td class="px-4 py-3">
                                     @if ($trial['days_left'] === null)
-                                        <span class="text-gray-400">-</span>
+                                        <span class="text-zinc-400">-</span>
                                     @elseif ($trial['days_left'] < 0)
                                         <flux:badge size="sm" color="red">Expiré</flux:badge>
                                     @else
@@ -118,64 +140,29 @@
 
     {{-- Activity KPIs --}}
     <flux:heading level="2" size="lg" class="mb-4">Activité</flux:heading>
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-2 mb-8">
-        <flux:card>
-            <flux:heading level="3" size="sm">Conversations</flux:heading>
-            <div class="mt-2 text-3xl font-bold">{{ $kpis['conversation_count'] }}</div>
-            <flux:text class="text-sm text-gray-500 mt-1">Sur la période sélectionnée</flux:text>
-        </flux:card>
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        @php
+            $activityCards = [
+                ['label' => 'Conversations CAO', 'value' => $kpis['conversation_count'], 'delta' => $kpis['deltas']['conversation_count']],
+                ['label' => 'Téléchargements', 'value' => $kpis['download_count'], 'delta' => $kpis['deltas']['download_count']],
+            ];
+        @endphp
 
-        <flux:card>
-            <flux:heading level="3" size="sm">Téléchargements</flux:heading>
-            <div class="mt-2 text-3xl font-bold">{{ $kpis['download_count'] }}</div>
-            <flux:text class="text-sm text-gray-500 mt-1">Sur la période sélectionnée</flux:text>
-        </flux:card>
-    </div>
-
-    {{-- Quick Links --}}
-    <flux:heading level="2" size="lg" class="mb-4">Accès rapide</flux:heading>
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <flux:button href="{{ route('ai-cad.admin.purchases.index') }}" variant="outline" class="justify-start">
-            <flux:icon name="banknotes" class="mr-2" />
-            Voir les achats
-        </flux:button>
-        <flux:button href="{{ route('ai-cad.admin.chats.index') }}" variant="outline" class="justify-start">
-            <flux:icon name="chat-bubble-left-right" class="mr-2" />
-            Voir les conversations
-        </flux:button>
-        <flux:button href="{{ route('ai-cad.admin.products.index') }}" variant="outline" class="justify-start">
-            <flux:icon name="cube" class="mr-2" />
-            Produits Stripe
-        </flux:button>
-        <flux:button href="{{ route('ai-cad.admin.downloads.index') }}" variant="outline" class="justify-start">
-            <flux:icon name="arrow-down-tray" class="mr-2" />
-            Voir les téléchargements
-        </flux:button>
-        <flux:button href="{{ route('ai-cad.admin.prompts.index') }}" variant="outline" class="justify-start">
-            <flux:icon name="document-text" class="mr-2" />
-            Gérer les prompts
-        </flux:button>
-        <flux:button href="{{ route('ai-cad.admin.step-messages.index') }}" variant="outline" class="justify-start">
-            <flux:icon name="chat-bubble-bottom-center" class="mr-2" />
-            Gérer les messages d'étapes
-        </flux:button>
-        @if(Route::has('admin.tolerycad.beta-testers'))
-            <flux:button href="{{ route('admin.tolerycad.beta-testers') }}" variant="outline" class="justify-start">
-                <flux:icon name="user-group" class="mr-2" />
-                Gérer les beta testeurs
-            </flux:button>
-        @endif
-        @if(Route::has('admin.tolerycad.dfm-error-codes'))
-            <flux:button href="{{ route('admin.tolerycad.dfm-error-codes') }}" variant="outline" class="justify-start">
-                <flux:icon name="exclamation-triangle" class="mr-2" />
-                Gérer les codes d'erreurs DFM
-            </flux:button>
-        @endif
-        @if(Route::has('admin.tolerycad.subscriptions'))
-            <flux:button href="{{ route('admin.tolerycad.subscriptions') }}" variant="outline" class="justify-start">
-                <flux:icon name="credit-card" class="mr-2" />
-                Suivre les abonnements
-            </flux:button>
-        @endif
+        @foreach ($activityCards as $card)
+            <flux:card class="flex flex-col gap-2">
+                <flux:text class="text-sm font-medium text-zinc-500">{{ $card['label'] }}</flux:text>
+                <div class="text-2xl font-bold tabular-nums">{{ $card['value'] }}</div>
+                @if ($card['delta'] !== null)
+                    <div>
+                        <flux:badge :color="$deltaColor($card['delta'])" size="sm">
+                            {{ $card['delta'] > 0 ? '+' : '' }}{{ $card['delta'] }}
+                        </flux:badge>
+                        <flux:text class="ml-1 text-xs text-zinc-500">vs période précédente</flux:text>
+                    </div>
+                @else
+                    <flux:text class="text-xs text-zinc-400">Sur la période sélectionnée</flux:text>
+                @endif
+            </flux:card>
+        @endforeach
     </div>
 </div>

--- a/src/Livewire/Admin/Dashboard.php
+++ b/src/Livewire/Admin/Dashboard.php
@@ -118,7 +118,7 @@ class Dashboard extends Component
      *
      * @return array{purchase_amount: int, subscription_amount: int, purchase_count: int, conversation_count: int, download_count: int}
      */
-    private function windowMetrics(?Carbon $start, ?Carbon $end, bool $hasDateFilter): array
+    private function windowMetrics(?\Carbon\Carbon $start, ?\Carbon\Carbon $end, bool $hasDateFilter): array
     {
         $purchaseQuery = FilePurchase::query();
         $chatQuery = Chat::query();

--- a/src/Livewire/Admin/Dashboard.php
+++ b/src/Livewire/Admin/Dashboard.php
@@ -36,7 +36,10 @@ class Dashboard extends Component
      *     download_count: int,
      *     subscription_count: int,
      *     trialing_count: int,
-     *     subscriptions_by_product: array<string, int>
+     *     paying_count: int,
+     *     at_risk_count: int,
+     *     subscriptions_by_product: array<string, int>,
+     *     deltas: array{total_revenue: ?float, subscription_revenue: ?float, purchase_revenue: ?float, conversation_count: ?int, download_count: ?int}
      * }
      */
     public function getKpis(): array
@@ -53,72 +56,141 @@ class Dashboard extends Component
         // "Tout le temps" : start()/end() both return null — no date filter applied
         $hasDateFilter = $startDate !== null && $endDate !== null;
 
-        // Achats unitaires
-        $purchaseQuery = FilePurchase::query();
+        $current = $this->windowMetrics($startDate, $endDate, $hasDateFilter);
+
+        // Comparable previous window (same length, immediately before) for deltas.
+        // Only computed when a finite period is selected.
+        $previous = null;
         if ($hasDateFilter) {
-            $purchaseQuery->whereBetween('purchased_at', [$startDate, $endDate]);
-        }
-        $purchaseAmount = (clone $purchaseQuery)->sum('amount');
-        $purchaseCount = (clone $purchaseQuery)->count();
-
-        // Abonnements créés sur la période
-        $subscriptionsQuery = Subscription::query()
-            ->where('type', 'default')
-            ->whereIn('stripe_status', ['active', 'trialing']);
-        if ($hasDateFilter) {
-            $subscriptionsQuery->whereBetween('created_at', [$startDate, $endDate]);
-        }
-        $subscriptionsOnPeriod = $subscriptionsQuery->get();
-
-        // Calculer le revenu des abonnements
-        $subscriptionRevenue = 0;
-        foreach ($subscriptionsOnPeriod as $subscription) {
-            /** @phpstan-ignore-next-line - stripe_price is a dynamic attribute from Cashier */
-            $stripePrice = $subscription->stripe_price;
-            $price = SubscriptionPrice::where('stripe_price_id', $stripePrice)->first();
-            if ($price) {
-                $subscriptionRevenue += $price->amount;
-            }
+            $duration = (int) $startDate->diffInSeconds($endDate);
+            $previous = $this->windowMetrics(
+                $startDate->copy()->subSeconds($duration),
+                $startDate->copy(),
+                true,
+            );
         }
 
-        // Abonnements actifs actuels (pas limités à la période)
+        // Current snapshot (independent of the selected period)
         $activeSubscriptions = Subscription::query()
             ->where('type', 'default')
             ->whereIn('stripe_status', ['active', 'trialing'])
+            ->with('items')
             ->get();
 
-        // Grouper par produit
-        $subscriptionsByProduct = [];
-        foreach ($activeSubscriptions as $subscription) {
-            /** @var SubscriptionItem|null $item */
-            $item = $subscription->items()->first();
-            if ($item) {
-                /** @phpstan-ignore-next-line - stripe_product is a dynamic attribute from Cashier */
-                $stripeProduct = $item->stripe_product;
-                $product = SubscriptionProduct::where('stripe_id', $stripeProduct)->first();
-                $productName = $product->name ?? 'Inconnu';
-                $subscriptionsByProduct[$productName] = ($subscriptionsByProduct[$productName] ?? 0) + 1;
-            }
-        }
+        $subscriptionsByProduct = $this->groupByProduct($activeSubscriptions);
 
-        $chatQuery = Chat::query();
-        $downloadQuery = ChatDownload::query();
-        if ($hasDateFilter) {
-            $chatQuery->whereBetween('created_at', [$startDate, $endDate]);
-            $downloadQuery->whereBetween('downloaded_at', [$startDate, $endDate]);
-        }
+        // À risque : résiliation programmée encore en période de grâce.
+        $atRiskCount = Subscription::query()
+            ->where('type', 'default')
+            ->whereNotNull('ends_at')
+            ->where('ends_at', '>', now())
+            ->count();
+
+        $currentTotal = $current['purchase_amount'] + $current['subscription_amount'];
+        $previousTotal = $previous !== null
+            ? $previous['purchase_amount'] + $previous['subscription_amount']
+            : null;
 
         return [
-            'purchase_revenue' => $purchaseAmount / 100,
-            'subscription_revenue' => $subscriptionRevenue / 100,
-            'total_revenue' => ($purchaseAmount + $subscriptionRevenue) / 100,
-            'purchase_count' => $purchaseCount,
-            'conversation_count' => $chatQuery->count(),
-            'download_count' => $downloadQuery->count(),
+            'purchase_revenue' => $current['purchase_amount'] / 100,
+            'subscription_revenue' => $current['subscription_amount'] / 100,
+            'total_revenue' => $currentTotal / 100,
+            'purchase_count' => $current['purchase_count'],
+            'conversation_count' => $current['conversation_count'],
+            'download_count' => $current['download_count'],
             'subscription_count' => $activeSubscriptions->count(),
             'trialing_count' => $activeSubscriptions->where('stripe_status', 'trialing')->count(),
+            'paying_count' => $activeSubscriptions->where('stripe_status', 'active')->count(),
+            'at_risk_count' => $atRiskCount,
             'subscriptions_by_product' => $subscriptionsByProduct,
+            'deltas' => [
+                'total_revenue' => $this->deltaPct($previousTotal, $currentTotal),
+                'subscription_revenue' => $this->deltaPct($previous['subscription_amount'] ?? null, $current['subscription_amount']),
+                'purchase_revenue' => $this->deltaPct($previous['purchase_amount'] ?? null, $current['purchase_amount']),
+                'conversation_count' => $previous !== null ? $current['conversation_count'] - $previous['conversation_count'] : null,
+                'download_count' => $previous !== null ? $current['download_count'] - $previous['download_count'] : null,
+            ],
         ];
+    }
+
+    /**
+     * Period-dependent revenue and activity metrics for a single time window.
+     *
+     * @return array{purchase_amount: int, subscription_amount: int, purchase_count: int, conversation_count: int, download_count: int}
+     */
+    private function windowMetrics(?Carbon $start, ?Carbon $end, bool $hasDateFilter): array
+    {
+        $purchaseQuery = FilePurchase::query();
+        $chatQuery = Chat::query();
+        $downloadQuery = ChatDownload::query();
+        $subscriptionsQuery = Subscription::query()
+            ->where('type', 'default')
+            ->whereIn('stripe_status', ['active', 'trialing']);
+
+        if ($hasDateFilter) {
+            $purchaseQuery->whereBetween('purchased_at', [$start, $end]);
+            $chatQuery->whereBetween('created_at', [$start, $end]);
+            $downloadQuery->whereBetween('downloaded_at', [$start, $end]);
+            $subscriptionsQuery->whereBetween('created_at', [$start, $end]);
+        }
+
+        // Subscription revenue: sum each created subscription's plan amount,
+        // resolved in one batch to avoid N+1.
+        $subscriptions = $subscriptionsQuery->get(['id', 'stripe_price']);
+        $priceAmounts = SubscriptionPrice::query()
+            ->whereIn('stripe_price_id', $subscriptions->pluck('stripe_price')->filter()->unique()->all())
+            ->pluck('amount', 'stripe_price_id');
+
+        $subscriptionAmount = (int) $subscriptions->sum(
+            /** @phpstan-ignore-next-line - stripe_price is a dynamic Cashier attribute */
+            fn (Subscription $s) => (int) ($priceAmounts[$s->stripe_price] ?? 0)
+        );
+
+        return [
+            'purchase_amount' => (int) $purchaseQuery->sum('amount'),
+            'subscription_amount' => $subscriptionAmount,
+            'purchase_count' => $purchaseQuery->count(),
+            'conversation_count' => $chatQuery->count(),
+            'download_count' => $downloadQuery->count(),
+        ];
+    }
+
+    /**
+     * Count active/trialing subscriptions grouped by product name.
+     *
+     * @param  Collection<int, Subscription>  $activeSubscriptions
+     * @return array<string, int>
+     */
+    private function groupByProduct(Collection $activeSubscriptions): array
+    {
+        $productNames = SubscriptionProduct::query()->pluck('name', 'stripe_id');
+
+        $grouped = [];
+        foreach ($activeSubscriptions as $subscription) {
+            /** @var SubscriptionItem|null $item */
+            $item = $subscription->items->first();
+            if ($item === null) {
+                continue;
+            }
+
+            /** @phpstan-ignore-next-line - stripe_product is a dynamic Cashier attribute */
+            $productName = $productNames[$item->stripe_product] ?? 'Inconnu';
+            $grouped[$productName] = ($grouped[$productName] ?? 0) + 1;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Percentage change between two amounts, or null when there is no comparable base.
+     */
+    private function deltaPct(?int $previous, int $current): ?float
+    {
+        if ($previous === null || $previous === 0) {
+            return null;
+        }
+
+        return round((($current - $previous) / $previous) * 100, 1);
     }
 
     /**

--- a/tests/Feature/DashboardKpiDeltasTest.php
+++ b/tests/Feature/DashboardKpiDeltasTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Flux\DateRange;
+use Illuminate\Support\Facades\Date;
+use Laravel\Cashier\Subscription;
+use Tolery\AiCad\Livewire\Admin\Dashboard;
+use Tolery\AiCad\Models\Chat;
+use Tolery\AiCad\Models\ChatTeam;
+
+beforeEach(function () {
+    config(['ai-cad.chat_team_model' => ChatTeam::class]);
+    Date::setTestNow('2026-05-22 12:00:00');
+});
+
+afterEach(function () {
+    Date::setTestNow();
+});
+
+it('computes the activity delta against the previous comparable window', function () {
+    $team = ChatTeam::factory()->create();
+    // Current 7-day window: 3 conversations.
+    Chat::factory()->count(3)->create(['team_id' => $team->id, 'created_at' => now()->subDays(2)]);
+    // Previous 7-day window: 2 conversations.
+    Chat::factory()->count(2)->create(['team_id' => $team->id, 'created_at' => now()->subDays(9)]);
+
+    $dashboard = new Dashboard;
+    $dashboard->range = new DateRange(now()->subDays(7), now());
+
+    $kpis = $dashboard->getKpis();
+
+    expect($kpis['conversation_count'])->toBe(3)
+        ->and($kpis['deltas']['conversation_count'])->toBe(1)
+        // No revenue in either window → no comparable base → null delta.
+        ->and($kpis['deltas']['total_revenue'])->toBeNull();
+});
+
+it('splits active subscribers between paying and trialing counts', function () {
+    $payingTeam = ChatTeam::factory()->create();
+    $trialTeam = ChatTeam::factory()->create();
+
+    Subscription::query()->forceCreate([
+        'team_id' => $payingTeam->id,
+        'type' => 'default',
+        'stripe_id' => 'sub_paying',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_x',
+        'quantity' => 1,
+    ]);
+
+    Subscription::query()->forceCreate([
+        'team_id' => $trialTeam->id,
+        'type' => 'default',
+        'stripe_id' => 'sub_trial',
+        'stripe_status' => 'trialing',
+        'stripe_price' => 'price_x',
+        'quantity' => 1,
+        'trial_ends_at' => now()->addDays(5),
+    ]);
+
+    $kpis = (new Dashboard)->getKpis();
+
+    expect($kpis['paying_count'])->toBe(1)
+        ->and($kpis['trialing_count'])->toBe(1)
+        ->and($kpis['subscription_count'])->toBe(2);
+});


### PR DESCRIPTION
## Contexte
Ticket mn-tolery #2180 — refonte de l'admin des abonnements ToleryCAD. Volet package (le volet app est dans une PR mn-tolery dédiée).

## Changements
- **Dashboard refondu** (esthétique neutre zinc, cards KPI) :
  - deltas période-sur-période **réels** (revenus, conversations, téléchargements) via fenêtre de comparaison de même durée
  - compteurs abonnés payants / en essai / à risque (période de grâce)
  - répartition des abonnements actifs par plan (barres)
  - liste des comptes en essai avec jours restants
  - suppression des « Accès rapide » (remplacés par la 2e sidebar)
- **2e sidebar** : les pages admin index (dashboard, achats, produits, prompts, conversations, téléchargements, messages d'étape) passent sous `x-layout.admin.tolerycad` (composant fourni par l'app hôte mn-tolery).

## Tests
- `DashboardKpiDeltasTest` (delta activité, delta null sans base comparable, split payants/essai)
- Suite complète : 76 tests, 0 échec (Pint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)