### PR TITLE
feat: prioritize CAD generation by subscription plan

### DIFF
--- a/database/migrations/2026_05_27_000000_add_priority_to_subscription_products_table.php
+++ b/database/migrations/2026_05_27_000000_add_priority_to_subscription_products_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscription_products', function (Blueprint $table) {
+            // Generation priority (0-100) used to prioritize CAD generation by plan.
+            // Higher = higher priority. Null = no explicit priority (paid-tier floor).
+            $table->unsignedTinyInteger('priority')->nullable()->after('files_allowed');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscription_products', function (Blueprint $table) {
+            $table->dropColumn('priority');
+        });
+    }
+};

--- a/src/Http/Controllers/GenerationController.php
+++ b/src/Http/Controllers/GenerationController.php
@@ -81,6 +81,7 @@ class GenerationController extends Controller
             sessionId: $validated['session_id'] ?? null,
             isEditRequest: (bool) ($validated['is_edit_request'] ?? false),
             materialChoice: $validated['material_choice'] ?? 'STEEL',
+            priority: $chat->team?->getGenerationPriority() ?? 0,
         );
 
         Log::info('[AICAD] Generation dispatched', [

--- a/src/Jobs/GenerateCadJob.php
+++ b/src/Jobs/GenerateCadJob.php
@@ -40,8 +40,23 @@ class GenerateCadJob implements ShouldBeUnique, ShouldQueue
         public ?string $sessionId,
         public bool $isEditRequest,
         public string $materialChoice,
+        public int $priority = 0,
     ) {
-        $this->onQueue('tolerycad-long');
+        $this->onQueue(self::queueForPriority($priority));
+    }
+
+    /**
+     * Map a generation priority (0-100) to a weighted queue. Workers consume
+     * them high → normal → low so paid plans get a worker before free ones
+     * under contention. See HasSubscription::getGenerationPriority().
+     */
+    public static function queueForPriority(int $priority): string
+    {
+        return match (true) {
+            $priority >= 70 => 'tolerycad-long-high',
+            $priority >= 1 => 'tolerycad-long-normal',
+            default => 'tolerycad-long-low',
+        };
     }
 
     /**
@@ -91,6 +106,7 @@ class GenerateCadJob implements ShouldBeUnique, ShouldQueue
                 isEditRequest: $this->isEditRequest,
                 timeoutSec: 600,
                 materialChoice: $this->materialChoice,
+                priority: $this->priority,
                 onProgress: function (array $event) use ($message, &$lastDbWriteAt) {
                     $step = $event['step'] ?? null;
                     $pct = isset($event['overall_percentage']) ? (int) $event['overall_percentage'] : null;

--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -361,6 +361,7 @@ class Chatbot extends Component
             sessionId: $this->chat->session_id,
             isEditRequest: $this->shouldUseEditMode(),
             materialChoice: $materialChoice,
+            priority: $this->chat->team?->getGenerationPriority() ?? 0,
         );
 
         $this->dispatch('aicad-subscribe-progress',
@@ -471,6 +472,7 @@ class Chatbot extends Component
                 sessionId: $this->chat->session_id,
                 isEditRequest: $isEdit,
                 materialChoice: $materialChoice,
+                priority: $this->chat->team?->getGenerationPriority() ?? 0,
             );
 
             logger()->info('[AICAD] GenerateCadJob dispatched', [

--- a/src/Models/SubscriptionProduct.php
+++ b/src/Models/SubscriptionProduct.php
@@ -22,6 +22,7 @@ use Tolery\AiCad\Observers\SubscriptionProductObserver;
  * @property int $price
  * @property bool $active
  * @property int $files_allowed
+ * @property ?int $priority
  * @property string $stripe_id
  * @property string $stripe_price_id
  * @property ResetFrequency|null $frequency
@@ -42,6 +43,7 @@ class SubscriptionProduct extends Model
         'description',
         'image_url',
         'files_allowed',
+        'priority',
         'active',
         'frequency',
         'price',

--- a/src/Services/AICADClient.php
+++ b/src/Services/AICADClient.php
@@ -19,7 +19,7 @@ readonly class AICADClient
      *
      * @throws \RuntimeException
      */
-    public function streamDirectlyToOutput(string $message, ?string $projectId = null, bool $isEditRequest = false, int $timeoutSec = 600, string $materialChoice = 'STEEL'): void
+    public function streamDirectlyToOutput(string $message, ?string $projectId = null, bool $isEditRequest = false, int $timeoutSec = 600, string $materialChoice = 'STEEL', int $priority = 0): void
     {
         $url = $this->endpoint('/api/generate-cad-stream');
 
@@ -36,6 +36,12 @@ readonly class AICADClient
 
         if ($isEditRequest) {
             $queryParams['is_edit_request'] = 'true';
+        }
+
+        // Forwarded to DFM so it can prioritize generation by plan tier.
+        // No effect until the DFM scheduler honors it (see issue #2201).
+        if ($priority > 0) {
+            $queryParams['priority'] = (string) $priority;
         }
 
         $fullUrl = $url.'?'.http_build_query($queryParams);
@@ -231,6 +237,7 @@ readonly class AICADClient
         bool $isEditRequest,
         int $timeoutSec,
         string $materialChoice,
+        int $priority,
         callable $onProgress,
         callable $onComplete,
         callable $onError,
@@ -249,6 +256,12 @@ readonly class AICADClient
 
         if ($isEditRequest) {
             $queryParams['is_edit_request'] = 'true';
+        }
+
+        // Forwarded to DFM so it can prioritize generation by plan tier.
+        // No effect until the DFM scheduler honors it (see issue #2201).
+        if ($priority > 0) {
+            $queryParams['priority'] = (string) $priority;
         }
 
         $fullUrl = $url.'?'.http_build_query($queryParams);

--- a/src/Services/StripeSyncService.php
+++ b/src/Services/StripeSyncService.php
@@ -76,6 +76,7 @@ class StripeSyncService
     protected function syncProduct(Product $stripeProduct): SubscriptionProduct
     {
         $filesAllowed = $stripeProduct->metadata->files_allowed ?? null;
+        $priority = $stripeProduct->metadata->priority ?? null;
 
         $product = SubscriptionProduct::firstOrNew(['stripe_id' => $stripeProduct->id]);
 
@@ -86,6 +87,7 @@ class StripeSyncService
         $product->image_url = ! empty($images) ? $images[0] : null;
         $product->active = $stripeProduct->active;
         $product->files_allowed = $filesAllowed ? (int) $filesAllowed : null;
+        $product->priority = is_numeric($priority) ? (int) $priority : null;
 
         // Frequency drives the quota reset cadence used by LimitRenew.
         // Stripe products do not carry this notion, so we default to MONTHLY
@@ -157,10 +159,11 @@ class StripeSyncService
             'name' => $product->name,
             'description' => $product->description,
             'active' => $product->active,
-            'metadata' => [
+            'metadata' => array_filter([
                 'files_allowed' => (string) $product->files_allowed,
+                'priority' => $product->priority !== null ? (string) $product->priority : null,
                 'laravel_product_id' => (string) $product->id,
-            ],
+            ], static fn ($v) => $v !== null),
         ]);
     }
 

--- a/src/Traits/HasSubscription.php
+++ b/src/Traits/HasSubscription.php
@@ -7,6 +7,27 @@ use Tolery\AiCad\Models\SubscriptionProduct;
 
 trait HasSubscription
 {
+    /**
+     * Generation priority for a paid plan whose product has no explicit
+     * `priority` set. Sits above free (0) and below high-tier plans.
+     */
+    public const DEFAULT_PAID_GENERATION_PRIORITY = 50;
+
+    /**
+     * Generation priority (0-100) used to prioritize CAD generation by plan.
+     * Higher = higher priority. No active subscription => 0 (free tier).
+     */
+    public function getGenerationPriority(): int
+    {
+        $product = $this->getSubscriptionProduct();
+
+        if (! $product) {
+            return 0;
+        }
+
+        return $product->priority ?? self::DEFAULT_PAID_GENERATION_PRIORITY;
+    }
+
     public function getSubscriptionProduct(): ?SubscriptionProduct
     {
         $subscription = $this->subscription();

--- a/tests/Feature/GenerationPriorityTest.php
+++ b/tests/Feature/GenerationPriorityTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Tolery\AiCad\Jobs\GenerateCadJob;
+use Tolery\AiCad\Models\ChatTeam;
+use Tolery\AiCad\Models\SubscriptionProduct;
+
+beforeEach(function () {
+    config(['ai-cad.chat_team_model' => ChatTeam::class]);
+});
+
+/**
+ * Attaches an active subscription on $team pointing at $product.
+ */
+function subscribeTeamToProduct(ChatTeam $team, SubscriptionProduct $product): void
+{
+    $subscription = $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_'.bin2hex(random_bytes(4)),
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_test',
+        'quantity' => 1,
+    ]);
+
+    $subscription->items()->create([
+        'stripe_id' => 'si_'.bin2hex(random_bytes(4)),
+        'stripe_product' => $product->stripe_id,
+        'stripe_price' => 'price_test',
+        'quantity' => 1,
+    ]);
+}
+
+describe('GenerateCadJob::queueForPriority', function () {
+    it('maps priority to the weighted queue', function (int $priority, string $expected) {
+        expect(GenerateCadJob::queueForPriority($priority))->toBe($expected);
+    })->with([
+        'free (0)' => [0, 'tolerycad-long-low'],
+        'low paid (1)' => [1, 'tolerycad-long-normal'],
+        'mid (69)' => [69, 'tolerycad-long-normal'],
+        'high threshold (70)' => [70, 'tolerycad-long-high'],
+        'max (100)' => [100, 'tolerycad-long-high'],
+    ]);
+
+    it('routes the dispatched job onto the queue matching its priority', function () {
+        $job = new GenerateCadJob(
+            messageId: 1,
+            userMessage: 'plaque',
+            sessionId: null,
+            isEditRequest: false,
+            materialChoice: 'STEEL',
+            priority: 80,
+        );
+
+        expect($job->queue)->toBe('tolerycad-long-high');
+    });
+
+    it('defaults to the low queue when no priority is given', function () {
+        $job = new GenerateCadJob(
+            messageId: 1,
+            userMessage: 'plaque',
+            sessionId: null,
+            isEditRequest: false,
+            materialChoice: 'STEEL',
+        );
+
+        expect($job->queue)->toBe('tolerycad-long-low');
+    });
+});
+
+describe('HasSubscription::getGenerationPriority', function () {
+    it('returns 0 for a team without an active subscription', function () {
+        $team = ChatTeam::factory()->create();
+
+        expect($team->getGenerationPriority())->toBe(0);
+    });
+
+    it('returns the product priority for a subscribed team', function () {
+        $product = SubscriptionProduct::factory()->create([
+            'stripe_id' => 'prod_high',
+            'priority' => 80,
+            'active' => true,
+        ]);
+        $team = ChatTeam::factory()->create();
+        subscribeTeamToProduct($team, $product);
+
+        expect($team->getGenerationPriority())->toBe(80);
+    });
+
+    it('falls back to the paid-tier default when the product has no priority', function () {
+        $product = SubscriptionProduct::factory()->create([
+            'stripe_id' => 'prod_no_priority',
+            'priority' => null,
+            'active' => true,
+        ]);
+        $team = ChatTeam::factory()->create();
+        subscribeTeamToProduct($team, $product);
+
+        expect($team->getGenerationPriority())
+            ->toBe(ChatTeam::DEFAULT_PAID_GENERATION_PRIORITY);
+    });
+});

--- a/tests/Feature/StripeSyncServiceTest.php
+++ b/tests/Feature/StripeSyncServiceTest.php
@@ -45,6 +45,26 @@ it('sets frequency to MONTHLY by default when creating a new product', function 
     expect($product->frequency)->toBe(ResetFrequency::MONTHLY);
 });
 
+it('syncs the generation priority from Stripe metadata', function () {
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct([
+        'metadata' => ['files_allowed' => '100', 'priority' => '80'],
+    ]);
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->priority)->toBe(80);
+});
+
+it('leaves priority null when Stripe metadata omits it', function () {
+    $service = new StripeSyncService($this->aiCadStripe);
+    $stripeProduct = makeStripeProduct();
+
+    $product = invokeSyncProduct($service, $stripeProduct);
+
+    expect($product->priority)->toBeNull();
+});
+
 it('uses Stripe metadata frequency when provided', function () {
     $service = new StripeSyncService($this->aiCadStripe);
     $stripeProduct = makeStripeProduct([


### PR DESCRIPTION
## Contexte

Tolery-Dev/mn-tolery#2201 — prioriser la génération de pièce selon le plan d'abonnement (plan plus élevé = priorité plus haute).

Le calcul lourd étant côté DFM, ce changement câble la priorité **de bout en bout** : routage de queue côté Laravel **et** transmission d'un param `priority` à l'API DFM (sans effet tant que DFM ne l'honore pas — cf. spec dans l'issue).

## Changements

- **Migration** : `subscription_products.priority` (unsignedTinyInteger, nullable).
- **`SubscriptionProduct`** : `priority` fillable + PHPDoc.
- **`StripeSyncService`** : lecture/écriture de la metadata Stripe `priority`.
- **`HasSubscription::getGenerationPriority(): int`** : `0` sans abonnement, `priority` du produit sinon, fallback `50` si non défini.
- **`GenerateCadJob`** : param `priority`, `queueForPriority()` → `tolerycad-long-{high,normal,low}`, transmission au client.
- **`AICADClient`** : param `priority` ajouté en query DFM uniquement si `> 0` (les 2 méthodes SSE).
- **Sites de dispatch** (Chatbot ×2, GenerationController) : `priority: $chat->team?->getGenerationPriority() ?? 0`.

## Tests

- `GenerationPriorityTest` : mapping priorité→queue, routage du job, `getGenerationPriority` (0 / produit / fallback).
- `StripeSyncServiceTest` : sync `priority` depuis metadata + null si absent.
- Suite complète verte (178 assertions), Pint OK, PHPStan OK.

## Suite côté hôte (mn-tolery)

- Bump `tolery/ai-cad` → v1.17.0.
- **Ops** : workers `--queue=tolerycad-long-high,tolerycad-long-normal,tolerycad-long-low` (+ worker dédié `-low` anti-famine).
- **Data** : définir la metadata Stripe `priority` sur les produits.