### PR TITLE
fix: route Product* jobs through the AI-CAD Stripe account

### DIFF
--- a/src/Jobs/Stripe/ProductCreate.php
+++ b/src/Jobs/Stripe/ProductCreate.php
@@ -4,9 +4,9 @@ namespace Tolery\AiCad\Jobs\Stripe;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Laravel\Cashier\Cashier;
 use Stripe\Exception\ApiErrorException;
 use Tolery\AiCad\Models\SubscriptionProduct;
+use Tolery\AiCad\Services\AiCadStripe;
 
 class ProductCreate implements ShouldQueue
 {
@@ -21,27 +21,31 @@ class ProductCreate implements ShouldQueue
     }
 
     /**
-     * Execute the job.
+     * Execute the job. Uses the AI-CAD Stripe account (AICAD_STRIPE_SECRET),
+     * NOT the host app's Cashier account — the two are distinct.
      *
      * @throws ApiErrorException
      */
-    public function handle(): void
+    public function handle(AiCadStripe $stripe): void
     {
-        if (! $this->subscriptionProduct->stripe_id) {
-
-            $product = Cashier::stripe()->products->create($this->subscriptionProduct->toStripeObject());
-
-            $price = Cashier::stripe()->prices->create([
-                ...$this->subscriptionProduct->toStripePriceObject(),
-                'product' => $product->id,
-            ]);
-
-            Cashier::stripe()->products->update($product->id, ['default_price' => $price->id]);
-
-            $this->subscriptionProduct->updateQuietly([
-                'stripe_id' => $product->id,
-                'stripe_price_id' => $price->id,
-            ]);
+        if ($this->subscriptionProduct->stripe_id) {
+            return;
         }
+
+        $stripeClient = $stripe->client();
+
+        $product = $stripeClient->products->create($this->subscriptionProduct->toStripeObject());
+
+        $price = $stripeClient->prices->create([
+            ...$this->subscriptionProduct->toStripePriceObject(),
+            'product' => $product->id,
+        ]);
+
+        $stripeClient->products->update($product->id, ['default_price' => $price->id]);
+
+        $this->subscriptionProduct->updateQuietly([
+            'stripe_id' => $product->id,
+            'stripe_price_id' => $price->id,
+        ]);
     }
 }

--- a/src/Jobs/Stripe/ProductDelete.php
+++ b/src/Jobs/Stripe/ProductDelete.php
@@ -5,9 +5,9 @@ namespace Tolery\AiCad\Jobs\Stripe;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
-use Laravel\Cashier\Cashier;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\InvalidRequestException;
+use Tolery\AiCad\Services\AiCadStripe;
 
 class ProductDelete implements ShouldQueue
 {
@@ -22,15 +22,16 @@ class ProductDelete implements ShouldQueue
     }
 
     /**
-     * Execute the job.
+     * Execute the job. Uses the AI-CAD Stripe account (AICAD_STRIPE_SECRET),
+     * NOT the host app's Cashier account — the two are distinct.
      *
      * @throws ApiErrorException
      */
-    public function handle(): void
+    public function handle(AiCadStripe $stripe): void
     {
         try {
             // On ne peut pas supprimer un produit avec un prix associé via l'API, on le va donc juste le désactiver.
-            Cashier::stripe()
+            $stripe->client()
                 ->products
                 ->update($this->subscriptionProductStripeId, ['active' => false, 'metadata' => ['deleted' => 'true']]);
         } catch (InvalidRequestException $e) {

--- a/src/Jobs/Stripe/ProductUpdate.php
+++ b/src/Jobs/Stripe/ProductUpdate.php
@@ -5,10 +5,11 @@ namespace Tolery\AiCad\Jobs\Stripe;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
-use Laravel\Cashier\Cashier;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\InvalidRequestException;
+use Stripe\StripeClient;
 use Tolery\AiCad\Models\SubscriptionProduct;
+use Tolery\AiCad\Services\AiCadStripe;
 
 class ProductUpdate implements ShouldQueue
 {
@@ -23,18 +24,19 @@ class ProductUpdate implements ShouldQueue
     }
 
     /**
-     * Execute the job.
+     * Execute the job. Uses the AI-CAD Stripe account (AICAD_STRIPE_SECRET),
+     * NOT the host app's Cashier account — the two are distinct.
      *
      * @throws ApiErrorException
      */
-    public function handle(): void
+    public function handle(AiCadStripe $stripe): void
     {
         if (! $this->subscriptionProduct->stripe_id) {
             return;
         }
 
         try {
-            $this->pushToStripe();
+            $this->pushToStripe($stripe->client());
         } catch (InvalidRequestException $e) {
             if (! $this->isStripeMissingResource($e)) {
                 throw $e;
@@ -53,24 +55,22 @@ class ProductUpdate implements ShouldQueue
         }
     }
 
-    protected function pushToStripe(): void
+    protected function pushToStripe(StripeClient $stripeClient): void
     {
         $price = null;
 
         if ($this->updatePrice) {
             // On désactive tous les prix précédents
-            $prices = Cashier::stripe()->prices->all([
+            $prices = $stripeClient->prices->all([
                 'product' => $this->subscriptionProduct->stripe_id,
                 'active' => true,
             ]);
 
             foreach ($prices->data as $price) {
-                Cashier::stripe()->prices->update($price->id, ['active' => false]);
+                $stripeClient->prices->update($price->id, ['active' => false]);
             }
 
-            $price = Cashier::stripe()
-                ->prices
-                ->create($this->subscriptionProduct->toStripePriceObject());
+            $price = $stripeClient->prices->create($this->subscriptionProduct->toStripePriceObject());
         }
 
         $productParams = $this->subscriptionProduct->toStripeObject();
@@ -79,9 +79,7 @@ class ProductUpdate implements ShouldQueue
             $productParams['default_price'] = $price->id;
         }
 
-        Cashier::stripe()
-            ->products
-            ->update($this->subscriptionProduct->stripe_id, $productParams);
+        $stripeClient->products->update($this->subscriptionProduct->stripe_id, $productParams);
     }
 
     protected function recreateMissingStripeProduct(): void

--- a/tests/Feature/Job/StripeProductJobsResilienceTest.php
+++ b/tests/Feature/Job/StripeProductJobsResilienceTest.php
@@ -7,6 +7,7 @@ use Stripe\Exception\InvalidRequestException;
 use Tolery\AiCad\Jobs\Stripe\ProductCreate;
 use Tolery\AiCad\Jobs\Stripe\ProductUpdate;
 use Tolery\AiCad\Models\SubscriptionProduct;
+use Tolery\AiCad\Services\AiCadStripe;
 
 function makeStripeInvalidRequestException(string $message, ?string $code): InvalidRequestException
 {
@@ -55,7 +56,7 @@ describe('ProductUpdate handle() resilience', function () {
             makeStripeInvalidRequestException("No such product: 'prod_dead_xyz'", 'resource_missing')
         );
 
-        $job->handle();
+        $job->handle(Mockery::mock(AiCadStripe::class)->shouldIgnoreMissing());
 
         $product->refresh();
 
@@ -80,7 +81,9 @@ describe('ProductUpdate handle() resilience', function () {
             makeStripeInvalidRequestException('Parameter missing: name', 'parameter_missing')
         );
 
-        expect(fn () => $job->handle())->toThrow(InvalidRequestException::class);
+        $stripe = Mockery::mock(AiCadStripe::class)->shouldIgnoreMissing();
+
+        expect(fn () => $job->handle($stripe))->toThrow(InvalidRequestException::class);
 
         Bus::assertNotDispatched(ProductCreate::class);
         expect($product->fresh()->stripe_id)->toBe('prod_alive');
@@ -92,7 +95,10 @@ describe('ProductUpdate handle() resilience', function () {
 
         $product = SubscriptionProduct::withoutEvents(fn () => SubscriptionProduct::factory()->create(['stripe_id' => null]));
 
-        (new ProductUpdate($product))->handle();
+        $stripe = Mockery::mock(AiCadStripe::class);
+        $stripe->shouldNotReceive('client');
+
+        (new ProductUpdate($product))->handle($stripe);
 
         Bus::assertNotDispatched(ProductCreate::class);
     });


### PR DESCRIPTION
## Vraie cause de Nightwatch #280

Les jobs `ProductCreate` / `ProductUpdate` / `ProductDelete` appelaient `Cashier::stripe()` (compte Stripe de l'app hôte) au lieu de `AiCadStripe::client()` (le compte AI-CAD configuré via `AICAD_STRIPE_*`).

Sur staging/prod ces deux clés pointent vers **deux comptes Stripe distincts** :
- `STRIPE_SECRET` (Cashier) → compte Tolery principal
- `AICAD_STRIPE_SECRET` → compte AI-CAD (où vivent les abonnements ToleryCAD)

Du coup chaque dispatch tapait le mauvais compte → Stripe répondait `No such product` même pour des produits qui existaient bien sur le compte AI-CAD. `StripeSyncService` utilisait déjà `AiCadStripe`, ce qui explique que le sync marchait et pas les jobs.

## Changements

- `ProductCreate` / `ProductUpdate` / `ProductDelete` : injection de `AiCadStripe` via le container Laravel, `->client()` pour le StripeClient.
- La résilience `resource_missing` introduite en v1.17.1 reste (défense en profondeur).

## Pourquoi pas un revert v1.17.1 ?

La résilience est utile en soi (et bien testée). Cette PR la complète : sans elle, le code aurait pu créer des doublons sur le mauvais compte Stripe à la prochaine édition. Avec les deux, le mapping est correct ET on encaisse un `stripe_id` réellement périmé.

Suite complète verte (192 assertions), Pint OK, PHPStan OK.