### PR TITLE
feat: admin polish — clickable team cells, larger purchase modal, S3-safe downloads

### DIFF
--- a/resources/views/livewire/partials/purchase-modal.blade.php
+++ b/resources/views/livewire/partials/purchase-modal.blade.php
@@ -1,4 +1,4 @@
-<flux:modal name="purchase-or-subscribe" :open="$showPurchaseModal" wire:model="showPurchaseModal" class="space-y-6 min-w-[32rem]">
+<flux:modal name="purchase-or-subscribe" :open="$showPurchaseModal" wire:model="showPurchaseModal" class="space-y-6 w-full max-w-4xl">
     <div class="space-y-6">
         <div>
             <flux:heading size="lg" class="mb-2">Télécharger ce fichier CAO</flux:heading>

--- a/src/Livewire/Admin/ChatDownloadTable.php
+++ b/src/Livewire/Admin/ChatDownloadTable.php
@@ -3,9 +3,9 @@
 namespace Tolery\AiCad\Livewire\Admin;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Tolery\AiCad\Models\ChatDownload;
+use Tolery\AiCad\Support\AdminColumnHelpers;
 use Ultraviolettes\FluxDataTable\Livewire\FluxDataTable;
 
 class ChatDownloadTable extends FluxDataTable
@@ -32,7 +32,7 @@ class ChatDownloadTable extends FluxDataTable
             [
                 'label' => 'Équipe',
                 'field' => 'team_id',
-                'render' => fn ($row) => $row->team->name ?? '-',
+                'render' => fn ($row) => AdminColumnHelpers::teamLinkOrName($row->team),
             ],
             [
                 'label' => 'Conversation',
@@ -63,8 +63,7 @@ class ChatDownloadTable extends FluxDataTable
                         return '-';
                     }
 
-                    $disk = Storage::disk(config('ai-cad.storage_disk', 's3'));
-                    $useS3 = method_exists($disk->getAdapter(), 'temporaryUrl');
+                    $useS3 = AdminColumnHelpers::diskSupportsTemporaryUrl(config('ai-cad.storage_disk', 's3'));
 
                     $downloadUrl = $useS3
                         ? URL::temporarySignedRoute('ai-cad.admin.download.s3', now()->addMinutes(5), ['chat' => $row->chat->id])

--- a/src/Livewire/Admin/ChatTable.php
+++ b/src/Livewire/Admin/ChatTable.php
@@ -4,6 +4,7 @@ namespace Tolery\AiCad\Livewire\Admin;
 
 use Illuminate\Database\Eloquent\Builder;
 use Tolery\AiCad\Models\Chat;
+use Tolery\AiCad\Support\AdminColumnHelpers;
 use Ultraviolettes\FluxDataTable\Livewire\FluxDataTable;
 
 class ChatTable extends FluxDataTable
@@ -39,7 +40,7 @@ class ChatTable extends FluxDataTable
                 'label' => 'Équipe',
                 'field' => 'team_id',
                 'searchable' => true,
-                'render' => fn ($row) => '<span class="text-zinc-700 dark:text-zinc-300">'.e($row->team->name ?? '-').'</span>',
+                'render' => fn ($row) => AdminColumnHelpers::teamLinkOrName($row->team),
             ],
             [
                 'label' => 'Abonnement',

--- a/src/Livewire/Admin/FilePurchaseTable.php
+++ b/src/Livewire/Admin/FilePurchaseTable.php
@@ -3,10 +3,10 @@
 namespace Tolery\AiCad\Livewire\Admin;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Number;
 use Tolery\AiCad\Models\FilePurchase;
+use Tolery\AiCad\Support\AdminColumnHelpers;
 use Ultraviolettes\FluxDataTable\Livewire\FluxDataTable;
 
 class FilePurchaseTable extends FluxDataTable
@@ -33,7 +33,7 @@ class FilePurchaseTable extends FluxDataTable
             [
                 'label' => 'Équipe',
                 'field' => 'team_id',
-                'render' => fn ($row) => $row->team->name ?? '-',
+                'render' => fn ($row) => AdminColumnHelpers::teamLinkOrName($row->team),
             ],
             [
                 'label' => 'Montant',
@@ -65,8 +65,7 @@ class FilePurchaseTable extends FluxDataTable
                         return '-';
                     }
 
-                    $disk = Storage::disk(config('ai-cad.storage_disk', 's3'));
-                    $useS3 = method_exists($disk->getAdapter(), 'temporaryUrl');
+                    $useS3 = AdminColumnHelpers::diskSupportsTemporaryUrl(config('ai-cad.storage_disk', 's3'));
 
                     $downloadUrl = $useS3
                         ? URL::temporarySignedRoute('ai-cad.admin.download.s3', now()->addMinutes(5), ['chat' => $row->chat->id])

--- a/src/Support/AdminColumnHelpers.php
+++ b/src/Support/AdminColumnHelpers.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tolery\AiCad\Support;
+
+use BackedEnum;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+/**
+ * Tiny helpers used by the admin Livewire tables to keep their column
+ * `render` closures readable and DRY.
+ */
+class AdminColumnHelpers
+{
+    /**
+     * Render a team cell as a link to the host app's admin team page when the
+     * route is configured AND registered. Falls back to escaped plain text
+     * otherwise so the package keeps working in a host that doesn't expose a
+     * team admin page.
+     *
+     * `config('ai-cad.admin_team_route_name')` may be:
+     *   - a string  — same route for every team
+     *   - an array  — keyed by team type (e.g. ['client' => 'companies.client.detail'])
+     *                 with an optional 'default' fallback.
+     */
+    public static function teamLinkOrName(mixed $team): string
+    {
+        if (! $team) {
+            return '-';
+        }
+
+        $name = (string) ($team->name ?? '-');
+        $routeName = self::resolveTeamRouteName($team);
+
+        if (! $routeName || ! Route::has($routeName)) {
+            return e($name);
+        }
+
+        $routeKey = method_exists($team, 'getRouteKey') ? $team->getRouteKey() : ($team->id ?? null);
+
+        return '<a href="'.e(route($routeName, ['team' => $routeKey])).'" class="text-blue-600 hover:underline">'.e($name).'</a>';
+    }
+
+    /**
+     * Probe the configured storage disk for `temporaryUrl` support, swallowing
+     * any SDK misconfiguration so a single bad env var (missing AWS region,
+     * etc.) can't 500 an entire admin table. Falls back to "no temporary URL".
+     */
+    public static function diskSupportsTemporaryUrl(string $disk): bool
+    {
+        try {
+            return method_exists(Storage::disk($disk)->getAdapter(), 'temporaryUrl');
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private static function resolveTeamRouteName(mixed $team): ?string
+    {
+        $config = config('ai-cad.admin_team_route_name');
+
+        if (is_string($config)) {
+            return $config;
+        }
+
+        if (is_array($config)) {
+            $type = $team->type ?? null;
+            $key = strtolower((string) ($type instanceof BackedEnum ? $type->value : $type));
+
+            return $config[$key] ?? $config['default'] ?? null;
+        }
+
+        return null;
+    }
+}

--- a/tests/Feature/Support/AdminColumnHelpersTest.php
+++ b/tests/Feature/Support/AdminColumnHelpersTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Storage;
+use Tolery\AiCad\Support\AdminColumnHelpers;
+
+function makeFakeTeam(int $id, string $name, ?string $type = null): object
+{
+    return new class($id, $name, $type)
+    {
+        public function __construct(public int $id, public string $name, public mixed $type) {}
+
+        public function getRouteKey(): int
+        {
+            return $this->id;
+        }
+    };
+}
+
+describe('AdminColumnHelpers::teamLinkOrName', function () {
+    it('returns a dash for null', function () {
+        expect(AdminColumnHelpers::teamLinkOrName(null))->toBe('-');
+    });
+
+    it('returns escaped plain text when no route is configured', function () {
+        config()->set('ai-cad.admin_team_route_name', null);
+
+        $team = makeFakeTeam(1, 'Tolery <b>Acme</b>');
+
+        expect(AdminColumnHelpers::teamLinkOrName($team))->toBe('Tolery &lt;b&gt;Acme&lt;/b&gt;');
+    });
+
+    it('returns escaped plain text when the configured route does not exist', function () {
+        config()->set('ai-cad.admin_team_route_name', 'route.that.does.not.exist');
+
+        $team = makeFakeTeam(1, 'Acme');
+
+        expect(AdminColumnHelpers::teamLinkOrName($team))->toBe('Acme');
+    });
+
+    it('renders an anchor when the route is a string and exists', function () {
+        Route::get('/admin/teams/{team}', fn ($team) => $team)->name('admin.team.test.show');
+        app('router')->getRoutes()->refreshNameLookups();
+        config()->set('ai-cad.admin_team_route_name', 'admin.team.test.show');
+
+        $team = makeFakeTeam(42, 'Acme');
+
+        $html = AdminColumnHelpers::teamLinkOrName($team);
+
+        expect($html)->toContain('<a href="')
+            ->and($html)->toContain('/admin/teams/42')
+            ->and($html)->toContain('>Acme</a>');
+    });
+
+    it('picks the route per team type when config is an array', function () {
+        Route::get('/admin/clients/{team}', fn ($team) => $team)->name('test.client');
+        Route::get('/admin/prestataires/{team}', fn ($team) => $team)->name('test.prestataire');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        config()->set('ai-cad.admin_team_route_name', [
+            'client' => 'test.client',
+            'prestataire' => 'test.prestataire',
+        ]);
+
+        $client = makeFakeTeam(1, 'Client Co', 'client');
+        $presta = makeFakeTeam(2, 'Presta Co', 'prestataire');
+
+        expect(AdminColumnHelpers::teamLinkOrName($client))->toContain('/admin/clients/1');
+        expect(AdminColumnHelpers::teamLinkOrName($presta))->toContain('/admin/prestataires/2');
+    });
+
+    it('falls back to the "default" entry of an array config when type is unknown', function () {
+        Route::get('/admin/default/{team}', fn ($team) => $team)->name('test.default');
+        app('router')->getRoutes()->refreshNameLookups();
+
+        config()->set('ai-cad.admin_team_route_name', [
+            'default' => 'test.default',
+        ]);
+
+        $team = makeFakeTeam(7, 'No Type Team', 'mystery');
+
+        expect(AdminColumnHelpers::teamLinkOrName($team))->toContain('/admin/default/7');
+    });
+});
+
+describe('AdminColumnHelpers::diskSupportsTemporaryUrl', function () {
+    it('returns false when the disk throws on resolve', function () {
+        // Using a never-configured driver makes Storage::disk() throw.
+        config()->set('filesystems.disks.never-configured', null);
+
+        expect(AdminColumnHelpers::diskSupportsTemporaryUrl('never-configured'))->toBeFalse();
+    });
+
+    it('returns true for a local-style disk that exposes temporaryUrl support', function () {
+        // The "local" driver does not expose temporaryUrl; assert false on a real disk.
+        Storage::fake('local-test');
+
+        expect(AdminColumnHelpers::diskSupportsTemporaryUrl('local-test'))->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Contexte

Tolery-Dev/mn-tolery#2231 — polish admin ToleryCAD. Cette PR couvre les 3 items côté package :
- **#3** lien team cliquable sur les 3 tableaux admin (`ChatTable`, `ChatDownloadTable`, `FilePurchaseTable`)
- **#2** bug 500 « AWS region » sur l'onglet Téléchargements (et Achats)
- **#4** popup d'abonnement plus large

## Changements

### `Tolery\AiCad\Support\AdminColumnHelpers`

Nouveau helper centralisant 2 mini-utilitaires utilisés par les colonnes des tables :

- **`teamLinkOrName($team)`** : rend la cellule Équipe en `<a>` vers la page admin team de l'app hôte si `config('ai-cad.admin_team_route_name')` pointe sur une route enregistrée. Sinon retourne le nom escapé (le package reste autonome — sans config, comportement actuel inchangé).
  - Config en string : même route pour toutes les teams.
  - Config en array : route par type (`['client' => 'companies.client.detail', 'prestataire' => 'companies.prestataire.detail']`), avec entrée optionnelle `'default'`. Détecte le type via `\$team->type` (string ou BackedEnum).

- **`diskSupportsTemporaryUrl(\$disk)`** : sonde le disk configuré et retourne `false` si le SDK AWS plante (région manquante, credentials absents…). Ça évite que toute la table 500 — le bouton de téléchargement utilise alors la route non-S3.

### Tables admin
- `ChatTable::columns()`, `ChatDownloadTable::columns()`, `FilePurchaseTable::columns()` consomment le helper pour la colonne Équipe et la sonde de disk.

### `purchase-modal.blade.php`
- `min-w-[32rem]` → `w-full max-w-4xl` — la modale a maintenant l'espace pour les deux cartes (Abonnement vs Sans abonnement) côte à côte sur desktop, reste responsive sur mobile.

## Tests

`tests/Feature/Support/AdminColumnHelpersTest.php` — 8 cas, 11 assertions :
- `teamLinkOrName` : null, sans config, route inexistante, string config + route registrée, map par type, fallback `default`.
- `diskSupportsTemporaryUrl` : crash du SDK → `false` ; disk local sans temporaryUrl → `false`.

Suite complète verte (203 assertions), Pint OK, PHPStan OK.

## Côté hôte (mn-tolery)

Sera fait dans une PR mn-tolery séparée :
- `config/ai-cad.php` : `'admin_team_route_name' => ['client' => 'companies.client.detail', 'prestataire' => 'companies.prestataire.detail']`.
- Items menu (Achats + Abonnements à côté) et bandeau profil (prix one-shot) côté mn-tolery.