### PR TITLE
fix: display DFM error message (not raw code) in admin chat detail

### DIFF
--- a/resources/views/livewire/admin/chat-detail.blade.php
+++ b/resources/views/livewire/admin/chat-detail.blade.php
@@ -150,15 +150,16 @@
                             {{-- Message Text --}}
                             @if($message->message)
                                 @php
-                                    $trimmed = trim($message->message);
-                                    $isDfmError = $message->role === 'assistant' && isset($dfmErrorCodes[$trimmed]);
+                                    $dfmError = $message->role === 'assistant'
+                                        ? $this::matchDfmError($message->message, $dfmErrorCodes)
+                                        : null;
                                 @endphp
-                                @if($isDfmError)
+                                @if($dfmError)
                                     <div class="flex items-start gap-2 text-amber-800 dark:text-amber-200">
                                         <flux:icon.exclamation-triangle class="size-5 shrink-0 text-amber-500 mt-0.5" />
                                         <div>
-                                            <span class="text-xs font-mono text-amber-500">Code {{ $trimmed }}</span>
-                                            <p class="text-sm mt-0.5">{{ $dfmErrorCodes[$trimmed] }}</p>
+                                            <span class="text-xs font-mono text-amber-500">Code {{ $dfmError['code'] }}</span>
+                                            <p class="text-sm mt-0.5">{{ $dfmError['message'] }}</p>
                                         </div>
                                     </div>
                                 @else

--- a/src/Livewire/Admin/ChatDetail.php
+++ b/src/Livewire/Admin/ChatDetail.php
@@ -102,6 +102,40 @@ class ChatDetail extends Component
             ->all();
     }
 
+    /**
+     * Reproduit `checkDfmErrorCode()` du front (chat-messages.blade.php) côté
+     * serveur, pour afficher le message d'erreur traduit au lieu du code brut.
+     *
+     * Cas 1 : le contenu trimé est exactement un code (ex: "104.1").
+     * Cas 2 : un code connu est noyé dans un texte plus long (ex: "104.1\nVeuillez
+     * réessayer") — regex avec garde-fou pour ne pas matcher "104.1" dans "1104.10".
+     *
+     * @param  array<string, string>  $dfmErrorCodes
+     * @return array{code: string, message: string}|null
+     */
+    public static function matchDfmError(?string $text, array $dfmErrorCodes): ?array
+    {
+        if ($text === null || trim($text) === '') {
+            return null;
+        }
+
+        // Cas 1 : le contenu est exactement un code
+        $trimmed = trim($text);
+        if (isset($dfmErrorCodes[$trimmed])) {
+            return ['code' => $trimmed, 'message' => $dfmErrorCodes[$trimmed]];
+        }
+
+        // Cas 2 : un code est noyé dans un texte plus long
+        foreach ($dfmErrorCodes as $code => $message) {
+            $pattern = '/(^|[^\d.])'.preg_quote((string) $code, '/').'($|[^\d.])/';
+            if (preg_match($pattern, $text) === 1) {
+                return ['code' => (string) $code, 'message' => $message];
+            }
+        }
+
+        return null;
+    }
+
     public function render(): View
     {
         return view('ai-cad::livewire.admin.chat-detail', [

--- a/tests/Feature/DfmErrorCodeMatchTest.php
+++ b/tests/Feature/DfmErrorCodeMatchTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Tolery\AiCad\Livewire\Admin\ChatDetail;
+
+/**
+ * Couvre ChatDetail::matchDfmError() — le remplacement code DFM → message côté
+ * admin, qui doit refléter checkDfmErrorCode() du front (chat-messages.blade.php).
+ */
+$codes = [
+    '104.1' => 'Échec du serveur de génération de pièce — erreur d\'exécution.',
+    '102.1' => 'Le serveur FreeCAD est actuellement indisponible.',
+];
+
+it('matche un contenu qui est exactement un code (Cas 1)', function () use ($codes) {
+    expect(ChatDetail::matchDfmError('104.1', $codes))
+        ->toBe(['code' => '104.1', 'message' => $codes['104.1']]);
+});
+
+it('matche un contenu exact entouré d\'espaces', function () use ($codes) {
+    expect(ChatDetail::matchDfmError("  104.1\n", $codes))
+        ->toBe(['code' => '104.1', 'message' => $codes['104.1']]);
+});
+
+it('matche un code noyé dans un texte plus long (Cas 2)', function () use ($codes) {
+    expect(ChatDetail::matchDfmError("104.1\nVeuillez réessayer ultérieurement.", $codes))
+        ->toBe(['code' => '104.1', 'message' => $codes['104.1']]);
+
+    expect(ChatDetail::matchDfmError('Erreur lors de la génération : 104.1 — réessayez', $codes))
+        ->toBe(['code' => '104.1', 'message' => $codes['104.1']]);
+});
+
+it('ne matche pas un code partiel (garde-fou anti 1104.10)', function () use ($codes) {
+    expect(ChatDetail::matchDfmError('référence 1104.10 du lot', $codes))->toBeNull();
+});
+
+it('retourne null pour un texte sans code', function () use ($codes) {
+    expect(ChatDetail::matchDfmError('Votre pièce a bien été générée.', $codes))->toBeNull();
+});
+
+it('retourne null pour un contenu vide ou null', function () use ($codes) {
+    expect(ChatDetail::matchDfmError(null, $codes))->toBeNull();
+    expect(ChatDetail::matchDfmError('', $codes))->toBeNull();
+    expect(ChatDetail::matchDfmError('   ', $codes))->toBeNull();
+});
+
+it('retourne null quand la map de codes est vide', function () {
+    expect(ChatDetail::matchDfmError('104.1', []))->toBeNull();
+});


### PR DESCRIPTION
## Problème (feedback #2268, Arthur)

Dans l'admin ToleryCAD (chat detail), un message d'erreur DFM s'affichait encore en **code brut** (ex. `104.1`) au lieu du message traduit de la table de correspondance.

## Cause

L'admin ne remplaçait le code par son message que si le contenu trimé était **exactement** un code (`isset($dfmErrorCodes[$trimmed])`). Le front, lui, gère depuis #2065 le cas où le code est **noyé dans un texte** (ex. `104.1\nVeuillez réessayer`). L'admin n'avait jamais reçu cette amélioration.

## Correctif

- `ChatDetail::matchDfmError(?string $text, array $dfmErrorCodes): ?array` — méthode statique pure qui reproduit fidèlement `checkDfmErrorCode()` du front : Cas 1 (match exact) puis Cas 2 (regex `(^|[^\d.])code($|[^\d.])` avec garde-fou anti-`1104.10`).
- `chat-detail.blade.php` : appel au matcher au lieu du `isset()` exact.

Front vérifié inchangé (déjà correct).

## Tests

- `tests/Feature/DfmErrorCodeMatchTest.php` : 7 cas (exact / noyé / multiligne / garde-fou / texte normal / vide / map vide) ✅
- `composer test` ✅ (0 échec) · `pint --dirty` ✅
- Vérifié en live (`dev-mode.sh`) sur les 18 vrais codes : `104.1`, `104.1\n…`, `Erreur : 104.1 —` → message traduit ; `1104.10` / texte normal → non matché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)