### PR TITLE
fix: disambiguate fillet radius edit prompt (#2263)

### DIFF
--- a/resources/views/partials/cad-config-panel.blade.php
+++ b/resources/views/partials/cad-config-panel.blade.php
@@ -1226,7 +1226,11 @@
                         changes.push(`la profondeur à ${this.fmt(this.edits.depth)}`);
                     }
                     if (this.edits.radius && this.edits.radius !== m.radius) {
-                        changes.push(`le rayon à ${this.fmt(this.edits.radius)}`);
+                        // Préciser « de congé » pour un fillet : sans ça le prompt
+                        // générique « le rayon » peut être interprété par le chatbot
+                        // comme le rayon de pliage (cf. issue #2263).
+                        const radiusLabel = faceType === 'fillet' ? 'le rayon de congé' : 'le rayon';
+                        changes.push(`${radiusLabel} à ${this.fmt(this.edits.radius)}`);
                     }
 
                     // Taraudage (thread) - modifications spécifiques


### PR DESCRIPTION
## Problème (issue #2263, feedback nam/DFM)

Pour modifier le rayon d'un **congé** via le tableau de config, l'utilisateur devait taper manuellement « Changer le rayon de congé à X mm », sinon le chatbot pouvait modifier le rayon de **pliage** à la place.

## Cause

`saveEdits()` (`cad-config-panel.blade.php`) générait le prompt **générique** « Changer **le rayon** à X » pour tout type ayant un rayon (dont les fillets). Ambigu vs le pliage.

## Correctif

Pour `faceType === 'fillet'`, le prompt devient « Changer **le rayon de congé** à X mm ». Le pliage garde son prompt spécifique (« le rayon intérieur à X »).

## Note sur l'autre point de #2263 (valeur du rayon affichée fausse)

Investigation séparée : la valeur du rayon de congé affichée vient du champ `features[].radius` du JSON DFM, affiché **verbatim** par le front. Or l'export DFM marque `radius` comme *debug param* et le **supprime** désormais (`format_notes: "debug params removed (radius, ...)"`). C'est donc un sujet **côté DFM** (exposer un rayon de congé autoritatif, comme le pliage le fait via `inner/outer.radius`), pas un bug d'affichage front. Documenté sur l'issue pour l'équipe DFM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)