### PR TITLE
fix: default dfmErrorCodes to [] in admin chat-detail blade

### DIFF
--- a/resources/views/livewire/admin/chat-detail.blade.php
+++ b/resources/views/livewire/admin/chat-detail.blade.php
@@ -150,8 +150,10 @@
                             {{-- Message Text --}}
                             @if($message->message)
                                 @php
+                                    // $dfmErrorCodes ?? [] : filet de sécurité si un composant
+                                    // consommateur surcharge render() sans repasser la variable.
                                     $dfmError = $message->role === 'assistant'
-                                        ? $this::matchDfmError($message->message, $dfmErrorCodes)
+                                        ? $this::matchDfmError($message->message, $dfmErrorCodes ?? [])
                                         : null;
                                 @endphp
                                 @if($dfmError)


### PR DESCRIPTION
## Contexte

Le fix #2268 (v1.17.5) a fait passer le blade admin de `isset(\$dfmErrorCodes[...])` (tolère une variable absente) à `\$this::matchDfmError(\$message->message, \$dfmErrorCodes)` (exige un `array`).

Un consommateur qui sous-classe `ChatDetail` et **surcharge `render()`** sans repasser `dfmErrorCodes` (cas réel dans mn-tolery : `App\Livewire\Admin\AiCadChatDetail`) provoquait alors une `TypeError` (variable indéfinie → null → param `array`) → 500.

## Correctif

`\$dfmErrorCodes ?? []` dans le blade : dégradation propre (pas de remplacement) au lieu d'un crash. Filet de sécurité — la donnée doit toujours être passée pour que le remplacement fonctionne (le composant parent `ChatDetail::render()` le fait déjà).

🤖 Generated with [Claude Code](https://claude.com/claude-code)