### PR TITLE
feat: texte d'aide quand une face est sélectionnée

### DIFF
--- a/resources/views/livewire/partials/chat-composer.blade.php
+++ b/resources/views/livewire/partials/chat-composer.blade.php
@@ -1,5 +1,5 @@
 <footer class="bg-white shrink-0"
-    x-data="{ hasContent: false, busy: false }"
+    x-data="{ hasContent: false, busy: false, hasFaceSelection: false }"
     @cad-generation-ended.window="busy = false">
     <form wire:submit.prevent="send" class="px-6 pb-6 pt-4"
         @submit="if (busy) { $event.preventDefault(); return; } busy = true;">
@@ -11,9 +11,13 @@
                 data-face-selection-chips
                 class="hidden flex flex-wrap gap-2 mb-2"
                 @face-selection-changed.window="
-                    console.log('[DEBUG] Dispatching to Livewire, hasSelection:', $event.detail.hasSelection);
+                    hasFaceSelection = $event.detail.hasSelection;
                     $wire.dispatch('face-selection-state-changed', { hasSelection: $event.detail.hasSelection });
                 ">
+            </div>
+
+            <div class="text-xs text-gray-500" x-show="hasFaceSelection" x-cloak>
+                Votre demande sera appliquée uniquement à la face sélectionnée.
             </div>
 
             <div :class="busy ? 'opacity-50 pointer-events-none' : ''">


### PR DESCRIPTION
## Contexte
Issue Tolery-Dev/mn-tolery#2229 — feedback Arthur : dans le chat CAO, ajouter un texte expliquant qu'on peut modifier directement la partie sélectionnée.

## Changement
Ajout d'un texte d'aide sous le chip de face dans `chat-composer.blade.php` :

> Votre demande sera appliquée uniquement à la face sélectionnée.

- Affiché **uniquement** quand une face est sélectionnée (`x-show="hasFaceSelection"`, piloté par l'event `face-selection-changed` déjà émis par `FaceSelectionManager.js` avec `hasSelection: true/false`).
- Style `text-xs text-gray-500` + `x-cloak`, cohérent avec les autres textes d'aide du package.
- Nettoyage d'un `console.log('[DEBUG]…')` resté dans le handler.

## Tests
Changement template-only (Alpine) → vérification visuelle. Aucune logique PHP modifiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)