### PR TITLE
feat: nommer les fichiers téléchargés d'après la pièce et la version

### DIFF
--- a/src/Services/ZipGeneratorService.php
+++ b/src/Services/ZipGeneratorService.php
@@ -48,9 +48,10 @@ class ZipGeneratorService
             'ai_screenshot_path' => $message->ai_screenshot_path,
         ]);
 
-        // Generate ZIP file name: [team_name]_YYYYMMDD_HHMMSS_tolerycad.zip
-        $teamName = $chat->team->name ?? 'team';
-        $zipFileName = str($teamName)->slug().'_'.now()->format('Ymd_His').'_tolerycad.zip';
+        // Generate ZIP file name: [part_name]_[version]_YYYYMMDD_HHMMSS_tolerycad.zip
+        $version = $message->getVersionLabel() ?? 'export';
+        $baseName = $this->buildBaseName($chat, $version);
+        $zipFileName = $baseName.'_'.now()->format('Ymd_His').'_tolerycad.zip';
 
         // Create temporary ZIP file
         $tempZipPath = storage_path('app/temp/'.$zipFileName);
@@ -79,12 +80,12 @@ class ZipGeneratorService
 
         // Add STEP file (use raw path, not URL)
         if ($message->ai_step_path) {
-            $this->addStorageFileToZip($zip, $message->ai_step_path, 'STEP', $filesAdded);
+            $this->addStorageFileToZip($zip, $message->ai_step_path, 'STEP', $filesAdded, $baseName);
         }
 
         // Add Technical Drawing (PDF) (use raw path, not URL)
         if ($message->ai_technical_drawing_path) {
-            $this->addStorageFileToZip($zip, $message->ai_technical_drawing_path, 'PDF', $filesAdded);
+            $this->addStorageFileToZip($zip, $message->ai_technical_drawing_path, 'PDF', $filesAdded, $baseName.'_plan');
         }
 
         $zip->close();
@@ -147,11 +148,11 @@ class ZipGeneratorService
             ];
         }
 
-        // Generate ZIP file name with version: [team_name]_[version]_YYYYMMDD_HHMMSS_tolerycad.zip
+        // Generate ZIP file name with version: [part_name]_[version]_YYYYMMDD_HHMMSS_tolerycad.zip
         $chat = $message->chat;
-        $teamName = $chat->team->name ?? 'team';
         $version = $message->getVersionLabel() ?? 'export';
-        $zipFileName = str($teamName)->slug().'_'.$version.'_'.now()->format('Ymd_His').'_tolerycad.zip';
+        $baseName = $this->buildBaseName($chat, $version);
+        $zipFileName = $baseName.'_'.now()->format('Ymd_His').'_tolerycad.zip';
 
         // Create temporary ZIP file
         $tempZipPath = storage_path('app/temp/'.$zipFileName);
@@ -180,12 +181,12 @@ class ZipGeneratorService
 
         // Add STEP file (use raw path, not URL)
         if ($message->ai_step_path) {
-            $this->addStorageFileToZip($zip, $message->ai_step_path, 'STEP', $filesAdded);
+            $this->addStorageFileToZip($zip, $message->ai_step_path, 'STEP', $filesAdded, $baseName);
         }
 
         // Add Technical Drawing (PDF) (use raw path, not URL)
         if ($message->ai_technical_drawing_path) {
-            $this->addStorageFileToZip($zip, $message->ai_technical_drawing_path, 'PDF', $filesAdded);
+            $this->addStorageFileToZip($zip, $message->ai_technical_drawing_path, 'PDF', $filesAdded, $baseName.'_plan');
         }
 
         $zip->close();
@@ -225,11 +226,27 @@ class ZipGeneratorService
     }
 
     /**
+     * Build a human-friendly base file name from the chat part name and version,
+     * e.g. "support-moteur_v2". Falls back to the team name, then "piece".
+     */
+    private function buildBaseName(Chat $chat, ?string $version): string
+    {
+        $source = $chat->name ?: ($chat->team->name ?? 'piece');
+        $slug = str($source)->slug()->toString();
+
+        if ($slug === '') {
+            $slug = 'piece';
+        }
+
+        return $version ? $slug.'_'.$version : $slug;
+    }
+
+    /**
      * Add a file from Storage to the ZIP archive.
      * This method reads directly from Storage instead of using URLs,
      * avoiding SSL issues with local .test domains.
      */
-    private function addStorageFileToZip(ZipArchive $zip, string $storagePath, string $type, array &$filesAdded): void
+    private function addStorageFileToZip(ZipArchive $zip, string $storagePath, string $type, array &$filesAdded, ?string $desiredBaseName = null): void
     {
         Log::info("[ZIP GENERATOR] Processing {$type} file from storage", [
             'storage_path' => $storagePath,
@@ -252,8 +269,11 @@ class ZipGeneratorService
                 return;
             }
 
-            // Get filename from path
-            $filename = basename($storagePath);
+            // Build a human-friendly filename when a base name is provided, preserving the original extension.
+            $extension = pathinfo($storagePath, PATHINFO_EXTENSION);
+            $filename = $desiredBaseName !== null && $extension !== ''
+                ? $desiredBaseName.'.'.$extension
+                : basename($storagePath);
 
             // Add content directly to ZIP
             $zip->addFromString($filename, $content);

--- a/tests/Feature/ZipGeneratorServiceTest.php
+++ b/tests/Feature/ZipGeneratorServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+use Tolery\AiCad\Models\Chat;
+use Tolery\AiCad\Models\ChatMessage;
+use Tolery\AiCad\Models\ChatTeam;
+use Tolery\AiCad\Services\ZipGeneratorService;
+
+beforeEach(function () {
+    config(['ai-cad.chat_team_model' => ChatTeam::class]);
+    Storage::fake();
+});
+
+/**
+ * @return array{0: Chat, 1: ChatMessage}
+ */
+function makeChatWithCadFiles(?string $partName, string $teamName = 'Dupont Industries'): array
+{
+    $team = ChatTeam::factory()->create(['name' => $teamName]);
+    $chat = Chat::factory()->create(['team_id' => $team->id, 'name' => $partName]);
+
+    Storage::put('cad/source.step', 'STEP-CONTENT');
+    Storage::put('cad/source.pdf', 'PDF-CONTENT');
+
+    $message = ChatMessage::query()->create([
+        'chat_id' => $chat->id,
+        'role' => 'assistant',
+        'message' => 'done',
+        'ai_step_path' => 'cad/source.step',
+        'ai_cad_path' => 'cad/source.obj',
+        'ai_technical_drawing_path' => 'cad/source.pdf',
+    ]);
+
+    return [$chat, $message];
+}
+
+/**
+ * @return array<int, string>
+ */
+function zipEntryNames(string $zipPath): array
+{
+    $zip = new ZipArchive;
+    $zip->open($zipPath);
+
+    $names = [];
+    for ($i = 0; $i < $zip->numFiles; $i++) {
+        $names[] = $zip->getNameIndex($i);
+    }
+    $zip->close();
+
+    return $names;
+}
+
+it('names the chat zip and its files after the part name and version', function () {
+    [$chat] = makeChatWithCadFiles('Support Moteur');
+
+    $result = app(ZipGeneratorService::class)->generateChatFilesZip($chat);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['filename'])->toStartWith('support-moteur_v1_')
+        ->and($result['filename'])->toEndWith('_tolerycad.zip');
+
+    expect(zipEntryNames($result['path']))
+        ->toContain('support-moteur_v1.step')
+        ->toContain('support-moteur_v1_plan.pdf');
+});
+
+it('names a specific version zip after the part name and version', function () {
+    [, $message] = makeChatWithCadFiles('Equerre Inox');
+
+    $result = app(ZipGeneratorService::class)->generateMessageFilesZip($message);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['filename'])->toStartWith('equerre-inox_v1_')
+        ->and($result['filename'])->toEndWith('_tolerycad.zip');
+
+    expect(zipEntryNames($result['path']))
+        ->toContain('equerre-inox_v1.step')
+        ->toContain('equerre-inox_v1_plan.pdf');
+});
+
+it('falls back to the team name when the chat has no part name', function () {
+    [$chat] = makeChatWithCadFiles(null, teamName: 'Dupont Industries');
+
+    $result = app(ZipGeneratorService::class)->generateChatFilesZip($chat);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['filename'])->toStartWith('dupont-industries_v1_');
+
+    expect(zipEntryNames($result['path']))->toContain('dupont-industries_v1.step');
+});


### PR DESCRIPTION
## Contexte
Issue Tolery-Dev/mn-tolery#2198 — feedback Arthur : « nommer les fichiers quand on les télécharge ».

## Problème
Le ZIP était nommé `[slug-équipe]_[date]_tolerycad.zip` et surtout les fichiers **dans** l'archive (STEP, plan PDF) gardaient des noms opaques (`basename()` du chemin de storage, p.ex. `6849a3f2c8b40.step`).

## Changement
`ZipGeneratorService` :
- Nouveau helper `buildBaseName()` = slug du **nom de pièce** (`$chat->name`), fallback nom d'équipe puis `piece`.
- **Nom du ZIP** : `[piece]_[version]_[Ymd_His]_tolerycad.zip`.
- **Fichiers internes** renommés en `[piece]_[version].step` et `[piece]_[version]_plan.pdf`, extension d'origine préservée (`pathinfo`).
- S'applique au téléchargement du chat complet (`generateChatFilesZip`) **et** d'une version (`generateMessageFilesZip`). Le contrôleur app et le JS de download héritent automatiquement du nouveau nom (ils réutilisent `$result['filename']`).

## Tests
`tests/Feature/ZipGeneratorServiceTest.php` (Pest) — 3 cas : nom de pièce + version sur le ZIP et les entrées, version spécifique, fallback nom d'équipe. ✅ 13 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)