### PR TITLE
fix: déblocage composer + retouches UI chatbot (#2308, #2322)

### DIFF
--- a/resources/views/livewire/partials/chat-composer.blade.php
+++ b/resources/views/livewire/partials/chat-composer.blade.php
@@ -1,6 +1,7 @@
-<footer class="bg-white shrink-0"
+<footer class="bg-white shrink-0 border-t border-grey-stroke"
     x-data="{ hasContent: false, busy: false, hasFaceSelection: false }"
-    @cad-generation-ended.window="busy = false">
+    @cad-generation-ended.window="busy = false"
+    @composer-unlock.window="busy = false">
     <form wire:submit.prevent="send" class="px-6 pb-6 pt-4"
         @submit="if (busy) { $event.preventDefault(); return; } busy = true;">
         <div class="flex flex-col gap-2">
@@ -20,14 +21,15 @@
                 Votre demande sera appliquée uniquement à la face sélectionnée.
             </div>
 
-            <div :class="busy ? 'opacity-50 pointer-events-none' : ''">
+            <div class="rounded-2xl transition-shadow duration-300"
+                 :class="{ 'opacity-50 pointer-events-none': busy, 'ring-1 ring-violet-500/40 shadow-[0_0_10px_1px_rgba(139,92,246,0.28)]': hasContent && !busy }">
                 <flux:composer
                     wire:key="{{ $composerPlaceholder }}"
                     wire:model="message"
                     submit="send"
                     :placeholder="$composerPlaceholder"
                     x-on:input="$dispatch('composer-input', { value: $event.target.value })"
-                    x-on:keydown.enter="if (!$event.shiftKey && !busy) { $event.preventDefault(); busy = true; $wire.send() }"
+                    x-on:keydown.enter="if (!$event.shiftKey && !busy && hasContent) { $event.preventDefault(); busy = true; $wire.send() }"
                     @composer-input.window="hasContent = $event.detail.value?.trim().length > 0">
                 </flux:composer>
             </div>
@@ -35,9 +37,11 @@
             <div class="flex items-center justify-end">
                 <button
                     type="submit"
-                    :disabled="busy"
-                    class="w-6 h-6 transition-all flex items-center justify-center"
-                    :class="busy ? 'opacity-40 cursor-not-allowed' : (hasContent ? 'scale-110 cursor-pointer hover:opacity-80' : 'cursor-pointer hover:opacity-80')">
+                    :disabled="busy || !hasContent"
+                    class="flex items-center gap-1.5 transition-all"
+                    :class="(busy || !hasContent) ? 'opacity-40 cursor-not-allowed' : 'scale-105 cursor-pointer hover:opacity-80'">
+                    <span class="text-sm font-medium transition-colors"
+                          :class="(busy || !hasContent) ? 'text-[#565C66]' : 'text-violet-600'">Envoyer</span>
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" class="w-6 h-6 transition-colors">
                         <g clip-path="url(#clip0_2847_31394)">
                             <path d="M3.4 20.3995L20.85 12.9195C21.66 12.5695 21.66 11.4295 20.85 11.0795L3.4 3.59953C2.74 3.30953 2.01 3.79953 2.01 4.50953L2 9.11953C2 9.61953 2.37 10.0495 2.87 10.1095L17 11.9995L2.87 13.8795C2.37 13.9495 2 14.3795 2 14.8795L2.01 19.4895C2.01 20.1995 2.74 20.6895 3.4 20.3995Z" :fill="busy ? '#c4c4c4' : (hasContent ? '#7C3AED' : '#565C66')"/>

--- a/resources/views/livewire/partials/chat-empty-state.blade.php
+++ b/resources/views/livewire/partials/chat-empty-state.blade.php
@@ -40,7 +40,7 @@
                 </div>
             </div>
 
-            <div class="relative bg-white border-[0.5px] border-[#D7DBE0] rounded-lg p-4 flex gap-2">
+            <div class="relative bg-white border-[0.5px] border-[#D7DBE0] rounded-lg p-4 flex gap-2 opacity-60">
                 <div class="shrink-0 w-10 h-10 pt-4">
                     <img src="{{ asset('vendor/ai-cad/images/pdf.svg') }}" alt="PDF to CAD">
                 </div>
@@ -70,7 +70,7 @@
                 </div>
             </div>
 
-            <div class="relative bg-white border-[0.5px] border-[#D7DBE0] rounded-lg p-4 flex gap-2">
+            <div class="relative bg-white border-[0.5px] border-[#D7DBE0] rounded-lg p-4 flex gap-2 opacity-60">
                 <div class="shrink-0 w-10 h-10 pt-4">
                     <img src="{{ asset('vendor/ai-cad/images/cad.svg') }}" alt="Tolery CAD files">
                 </div>

--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -373,10 +374,22 @@ class Chatbot extends Component
     public function send(RateLimiter $limiter): void
     {
         if ($this->isProcessing) {
+            // Relâche le verrou optimiste du composer (flag Alpine `busy`) : sans cela
+            // la zone de saisie reste figée car seul `cad-generation-ended` la libère. (#2308)
+            $this->dispatch('composer-unlock');
+
             return;
         }
 
-        $this->validate();
+        try {
+            $this->validate();
+        } catch (ValidationException $e) {
+            // Message vide ou trop court : on débloque le composer avant de laisser
+            // Livewire afficher l'erreur, sinon `busy` reste coincé à true. (#2308)
+            $this->dispatch('composer-unlock');
+
+            throw $e;
+        }
 
         // Si le chat n'existe pas encore, le créer MAINTENANT
         if (! $this->chat->exists) {
@@ -413,6 +426,7 @@ class Chatbot extends Component
             $wait = $limiter->availableIn($rateKey);
             $this->appendAssistant("Vous envoyez des messages trop vite. Réessayez dans {$wait}s.");
             $this->dispatch('tolery-chat-append');
+            $this->dispatch('composer-unlock');
 
             return;
         }
@@ -421,6 +435,8 @@ class Chatbot extends Component
 
         $lock = Cache::lock("aicad:send:chat:{$this->chat->id}", $this->lockSeconds);
         if (! $lock->get()) {
+            $this->dispatch('composer-unlock');
+
             return;
         }
         try {


### PR DESCRIPTION
## Contexte

Corrige deux retours client sur le chatbot ToleryCAD (issues mn-tolery #2308 et #2322).

## #2308 — Composer bloqué après un envoi invalide

Le flag Alpine `busy` du composer passait à `true` au submit mais n'était relâché que par l'événement `cad-generation-ended`, lui-même émis **uniquement** quand une génération démarrait réellement. Toute sortie anticipée de `Chatbot::send()` (validation `min:2`, rate-limit, lock non acquis, `isProcessing`) laissait donc le composer figé (`opacity-50 pointer-events-none`), sans aucun moyen de réécrire — exactement le blocage signalé.

**Correctif (défensif, 2 niveaux) :**
- `Chatbot::send()` dispatch `composer-unlock` sur **chaque** sortie anticipée (validation échouée incluse, via `try/catch ValidationException`).
- Le `<footer>` écoute `@composer-unlock.window` pour remettre `busy = false`.
- Le bouton submit est désactivé et l'envoi par `Entrée` est ignoré quand le champ est vide (`hasContent`) → supprime le déclencheur principal.

## #2322 — Retouches UI

1. Glow violet (`ring-1` + `shadow`) autour du textarea, visible quand on saisit du texte.
2. Cartes **pdf-to-cad** / **cad-to-cad** estompées (`opacity-60`) pour signaler « bientôt disponible ».
3. Séparation visuelle du composer (`border-t`) — meilleure lisibilité sur petits écrans.
4. Libellé « Envoyer » en violet devant la flèche.

## Tests
- `vendor/bin/pint --dirty` ✅
- `composer test` ✅ (113 deprecated PDO/PHP 8.5 non-bloquants, 0 échec)
- Validé visuellement de bout en bout dans l'app hôte (vendor copié + CSS rebuild), y compris le scénario de blocage #2308 (composer non figé après envoi invalide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)