### PR TITLE
fix: charger les codes erreurs DFM au mount même sur un ghost chat

### DIFF
--- a/src/Livewire/Chatbot.php
+++ b/src/Livewire/Chatbot.php
@@ -98,6 +98,12 @@ class Chatbot extends Component
         $user = auth()->user();
         $this->quotaStatus = app(FileAccessService::class)->getQuotaStatus($user->team);
 
+        // Charger les codes d'erreur DFM avant le early return : un ghost chat
+        // créé en lazy dans send() ne repasse jamais par mount() (l'URL est mise
+        // à jour via History API, sans remount), donc la propriété resterait
+        // vide pour toute la session et le front afficherait le code brut (#2338)
+        $this->dfmErrorCodes = $this->loadDfmErrorCodes();
+
         // Si le chat n'existe pas encore (ghost chat), ne rien faire
         // Il sera créé au premier message envoyé
         if (! $this->chat->exists) {
@@ -136,9 +142,6 @@ class Chatbot extends Component
             // 4. Initialize download status
             $this->updateDownloadStatus();
         }
-
-        // Charger les codes d'erreur DFM pour le mapping côté frontend
-        $this->dfmErrorCodes = $this->loadDfmErrorCodes();
 
         // Détecter une génération orpheline : dernier message = user sans réponse assistant
         $lastMsg = $this->chat->messages()

--- a/tests/Feature/ChatbotDfmErrorCodesMountTest.php
+++ b/tests/Feature/ChatbotDfmErrorCodesMountTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
+use Tolery\AiCad\Livewire\Chatbot;
+use Tolery\AiCad\Models\Chat;
+use Tolery\AiCad\Models\ChatTeam;
+use Tolery\AiCad\Models\ChatUser;
+use Tolery\AiCad\Services\FileAccessService;
+
+/**
+ * Régression #2338 : sur un ghost chat (nouveau fichier), mount() sortait avant
+ * de charger $dfmErrorCodes. Le chat étant ensuite créé en lazy dans send()
+ * (URL mise à jour via History API, sans remount), la propriété restait vide
+ * pour toute la session et le front affichait le code DFM brut (ex: « 104.1 »)
+ * au lieu du message utilisateur.
+ */
+class ChatbotMountTestDfmErrorCode extends Model
+{
+    protected $table = 'dfm_error_codes';
+
+    protected $guarded = [];
+}
+
+beforeEach(function () {
+    Schema::create('dfm_error_codes', function (Blueprint $table) {
+        $table->id();
+        $table->string('code');
+        $table->string('message_fr')->nullable();
+        $table->string('message_en')->nullable();
+        $table->timestamps();
+    });
+
+    ChatbotMountTestDfmErrorCode::create([
+        'code' => '104.1',
+        'message_fr' => "Échec d'exécution lors de la construction 3D.",
+        'message_en' => 'Execution failure during 3D construction.',
+    ]);
+
+    config(['ai-cad.dfm_error_code_model' => ChatbotMountTestDfmErrorCode::class]);
+
+    // Stub : évite la résolution d'AiCadStripe et le calcul de quota,
+    // hors du périmètre de ce test.
+    app()->instance(FileAccessService::class, new class extends FileAccessService
+    {
+        public function __construct() {}
+
+        public function getQuotaStatus(?ChatTeam $team): ?array
+        {
+            return null;
+        }
+    });
+
+    $user = new ChatUser(['name' => 'Test User']);
+    $user->setRelation('team', null);
+    Auth::setUser($user);
+});
+
+function mountChatbotWithGhostChat(): Chatbot
+{
+    $component = new Chatbot;
+    $component->chat = new Chat;
+    $component->mount();
+
+    return $component;
+}
+
+it('charge les codes erreurs DFM au mount même sur un ghost chat (régression #2338)', function () {
+    app()->setLocale('fr');
+
+    $component = mountChatbotWithGhostChat();
+
+    expect($component->dfmErrorCodes)
+        ->toBe(['104.1' => "Échec d'exécution lors de la construction 3D."]);
+});
+
+it('conserve le early return ghost chat : pas de messages chargés', function () {
+    app()->setLocale('fr');
+
+    $component = mountChatbotWithGhostChat();
+
+    expect($component->messages)->toBe([]);
+});
+
+it('utilise message_en pour une locale non française', function () {
+    app()->setLocale('en');
+
+    $component = mountChatbotWithGhostChat();
+
+    expect($component->dfmErrorCodes)
+        ->toBe(['104.1' => 'Execution failure during 3D construction.']);
+});


### PR DESCRIPTION
## Contexte

Tolery-Dev/mn-tolery#2338 — en prod, le chatbot affichait le code DFM brut (« 104.1 ») au lieu du message utilisateur, alors que la table `dfm_error_codes` est peuplée et que le lookup serveur fonctionnait (`has_dfm_error` correctement positionné en base).

## Cause racine

Dans `Chatbot::mount()`, le early return du ghost chat (nouveau fichier) se faisait **avant** le chargement de `$dfmErrorCodes`. Le chat est ensuite créé en lazy dans `send()` et l'URL mise à jour via History API — **sans remount**. La propriété restait donc vide pour toute la session : chaque bulle recevait `Js::from([])` et `checkDfmErrorCode()` ne matchait jamais.

Le « ça marche en local » était une illusion d'observation : sur un chat existant ou une page rechargée, `mount()` charge bien les codes. Le bug est reproductible en local sur un chat fraîchement créé.

## Fix

Déplacement du chargement de `$dfmErrorCodes` avant le early return (1 ligne déplacée).

## Tests

- `ChatbotDfmErrorCodesMountTest` : 3 tests, dont 2 échouent sans le fix (vérifié par stash/run/pop).
- Suite complète : 116 tests / 229 assertions ✅ (bruit `PDO::MYSQL_ATTR_SSL_CA` connu sous PHP 8.5).

Fixes Tolery-Dev/mn-tolery#2338

🤖 Generated with [Claude Code](https://claude.com/claude-code)