### PR TITLE
fix: wording popup génération CAO (mn-tolery#2345)

### DIFF
--- a/resources/views/livewire/partials/viewer-panel.blade.php
+++ b/resources/views/livewire/partials/viewer-panel.blade.php
@@ -6,7 +6,7 @@
              class="absolute inset-0 z-50 flex items-start justify-center pt-8 bg-white">
             <div class="w-full max-w-4xl mx-4">
                 <div class="bg-gradient-to-r from-violet-600 to-indigo-800 px-6 py-4 text-white flex items-center justify-between rounded-t-2xl">
-                    <h3 class="text-lg font-semibold">Création de votre fichier CAO en cours</h3>
+                    <h3 class="text-lg font-semibold">La génération de votre fichier peut mettre quelques secondes à plusieurs minutes selon la complexité</h3>
                     <div class="text-sm" x-text="`${completedSteps} sur 5 étapes terminées`"></div>
                 </div>
 
@@ -85,7 +85,6 @@
                             </svg>
                             <div class="flex-1">
                                 <p class="text-sm font-medium text-violet-900 mb-1">Vous pouvez fermer cette fenêtre</p>
-                                <p class="text-xs text-violet-700">La génération continue en arrière-plan. Vous serez notifié dès que votre pièce sera prête.</p>
                             </div>
                         </div>
                     </template>


### PR DESCRIPTION
## Résumé

Mise à jour du wording de la popup affichée pendant la génération de fichier CAO.

**Avant :**
- Titre : `Création de votre fichier CAO en cours`
- Sous-titre : `Vous pouvez fermer cette fenêtre` + `La génération continue en arrière-plan. Vous serez notifié dès que votre pièce sera prête.`

**Après :**
- Titre : `La génération de votre fichier peut mettre quelques secondes à plusieurs minutes selon la complexité`
- Sous-titre : `Vous pouvez fermer cette fenêtre`

Aucun changement de comportement — uniquement le texte affiché dans `resources/views/livewire/partials/viewer-panel.blade.php`.

Voir issue Tolery-Dev/mn-tolery#2345

🤖 Generated with [Claude Code](https://claude.com/claude-code)